### PR TITLE
fix: check stdConn buffer is nil when ResetBuffer

### DIFF
--- a/connection_windows.go
+++ b/connection_windows.go
@@ -109,7 +109,10 @@ func (c *stdConn) Read() []byte {
 }
 
 func (c *stdConn) ResetBuffer() {
-	c.buffer.Reset()
+	if c.buffer != nil {
+		c.buffer.Reset()
+	}
+
 	c.inboundBuffer.Reset()
 	bytebuffer.Put(c.byteBuffer)
 	c.byteBuffer = nil


### PR DESCRIPTION
---
name: Pull request
about: fix stdConn ResetBuffer function on windows
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `ants`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?



## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->



## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [ ] I have squashed all insignificant commits.
- [ ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
