### PR TITLE
Create new eventloop connections

### DIFF
--- a/connection_windows.go
+++ b/connection_windows.go
@@ -22,7 +22,9 @@
 package gnet
 
 import (
+	"errors"
 	"net"
+	"reflect"
 
 	"github.com/panjf2000/gnet/pool/bytebuffer"
 	prb "github.com/panjf2000/gnet/pool/ringbuffer"
@@ -122,6 +124,18 @@ func (c *stdConn) read() ([]byte, error) {
 }
 
 // ================================= Public APIs of gnet.Conn =================================
+
+func (c *stdConn) Dial(addr string) (conn Conn, err error) {
+	_ = addr
+	return nil, errors.New("unsupported on windows")
+}
+
+func (c *stdConn) ID() int {
+	v := reflect.ValueOf(c.conn)
+	netFD := reflect.Indirect(reflect.Indirect(v).FieldByName("fd"))
+	fd := int(netFD.FieldByName("sysfd").Int())
+	return fd
+}
 
 func (c *stdConn) Read() []byte {
 	if c.inboundBuffer.IsEmpty() {

--- a/gnet.go
+++ b/gnet.go
@@ -94,6 +94,12 @@ func (s Server) DupFd() (dupFD int, err error) {
 
 // Conn is a interface of gnet connection.
 type Conn interface {
+	// Dial connects to addr returning a new Conn on the same eventloop as this Conn
+	Dial(addr string) (Conn, error)
+
+	// ID is the unique (per-process) identity of this Conn
+	ID() int
+
 	// Context returns a user-defined context.
 	Context() (ctx interface{})
 

--- a/internal/reuseport/reuseport.go
+++ b/internal/reuseport/reuseport.go
@@ -28,7 +28,14 @@ package reuseport
 
 import (
 	"net"
+
+	"golang.org/x/sys/unix"
 )
+
+// TCPConnect calls tcpConnectedSocket.
+func TCPConnect(proto, addr string) (int, bool, unix.Sockaddr, net.Addr, error) {
+	return tcpConnectedSocket(proto, addr)
+}
 
 // TCPSocket calls tcpReusablePort.
 func TCPSocket(proto, addr string, reusePort bool) (int, net.Addr, error) {

--- a/loop_bsd.go
+++ b/loop_bsd.go
@@ -24,8 +24,11 @@ package gnet
 
 import "github.com/panjf2000/gnet/internal/netpoll"
 
-func (el *eventloop) handleEvent(fd int, filter int16) error {
+func (el *eventloop) handleEvent(fd int, filter int16) (err error) {
 	if c, ok := el.connections[fd]; ok {
+		if err := el.handleConnecting(c); err != nil {
+			return err
+		}
 		if filter == netpoll.EVFilterSock {
 			return el.loopCloseConn(c, nil)
 		}

--- a/loop_linux.go
+++ b/loop_linux.go
@@ -24,6 +24,9 @@ import "github.com/panjf2000/gnet/internal/netpoll"
 
 func (el *eventloop) handleEvent(fd int, ev uint32) error {
 	if c, ok := el.connections[fd]; ok {
+		if err := el.handleConnecting(c); err != nil {
+			return err
+		}
 		switch c.outboundBuffer.IsEmpty() {
 		// Don't change the ordering of processing EPOLLOUT | EPOLLRDHUP / EPOLLIN unless you're 100%
 		// sure what you're doing!

--- a/website/highlights/2020-12-31-client-sockets.md
+++ b/website/highlights/2020-12-31-client-sockets.md
@@ -1,0 +1,16 @@
+---
+last_modified_on: "2020-12-08"
+$schema: "/.meta/.schemas/highlights.json"
+title: "New feature allows creating eventloop managed client sockets"
+description: "Open a client socket and react to events like accepted sockets"
+author_github: "https://github.com/hellertime"
+pr_numbers: [22b190f]
+release: "features"
+hide_on_release_notes: false
+tags: ["type: new feature", "domain: client", "platform: unix"]
+---
+
+## About this change
+
+Open connections to remote clients, and manage them as you do connections made to the Server. New Connection are created with a `Dial` method,
+which is part of the `Conn` interface, this assures the new socket is managed by the same eventloop as the `Conn` that created it.


### PR DESCRIPTION
## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?

New feature.

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Servers that need to create connections with peer nodes, currently have to manage these connections outside the `gnet` event loop. It would be ideal to manage these connections within the event loop. 

This change extends the Conn interface with a new Dial function, which gives the server a way to create a new TCP connection to a peer, and ensure its managed on the same event loop as the Conn that created it.

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->

Use case for this feature discussed in issue #143.

## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

This change extends the Conn interface and documents the new call with an appropriate Export Comment.

## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [x] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
