### PR TITLE
Prevent closed conn from execute any loop

### DIFF
--- a/eventloop_unix.go
+++ b/eventloop_unix.go
@@ -169,10 +169,6 @@ func (el *eventloop) loopRead(c *conn) error {
 }
 
 func (el *eventloop) loopWrite(c *conn) error {
-	if !c.opened {
-		return nil
-	}
-
 	el.eventHandler.PreWrite()
 
 	head, tail := c.outboundBuffer.LazyReadAll()

--- a/eventloop_unix.go
+++ b/eventloop_unix.go
@@ -125,10 +125,6 @@ func (el *eventloop) loopOpen(c *conn) error {
 }
 
 func (el *eventloop) loopRead(c *conn) error {
-	if !c.opened {
-		return nil
-	}
-
 	n, err := unix.Read(c.fd, el.packet)
 	if n == 0 || err != nil {
 		if err == unix.EAGAIN {
@@ -244,11 +240,8 @@ func (el *eventloop) loopCloseConn(c *conn, err error) (rerr error) {
 }
 
 func (el *eventloop) loopWake(c *conn) error {
-	//if co, ok := el.connections[c.fd]; !ok || co != c {
-	//	return nil // ignore stale wakes.
-	//}
-	if !c.opened {
-		return nil
+	if co, ok := el.connections[c.fd]; !ok || co != c {
+		return nil // ignore stale wakes.
 	}
 
 	out, action := el.eventHandler.React(nil, c)

--- a/eventloop_unix.go
+++ b/eventloop_unix.go
@@ -125,6 +125,10 @@ func (el *eventloop) loopOpen(c *conn) error {
 }
 
 func (el *eventloop) loopRead(c *conn) error {
+	if !c.opened {
+		return nil
+	}
+
 	n, err := unix.Read(c.fd, el.packet)
 	if n == 0 || err != nil {
 		if err == unix.EAGAIN {
@@ -165,6 +169,10 @@ func (el *eventloop) loopRead(c *conn) error {
 }
 
 func (el *eventloop) loopWrite(c *conn) error {
+	if !c.opened {
+		return nil
+	}
+
 	el.eventHandler.PreWrite()
 
 	head, tail := c.outboundBuffer.LazyReadAll()
@@ -243,6 +251,10 @@ func (el *eventloop) loopWake(c *conn) error {
 	//if co, ok := el.connections[c.fd]; !ok || co != c {
 	//	return nil // ignore stale wakes.
 	//}
+	if !c.opened {
+		return nil
+	}
+
 	out, action := el.eventHandler.React(nil, c)
 	if out != nil {
 		if err := c.write(out); err != nil {

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -180,7 +180,7 @@ func (el *eventloop) loopTicker() {
 
 func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 	defer func() {
-		if co, ok := el.connections[c]; !ok || co != c {
+		if _, ok := el.connections[c]; !ok {
 			return nil // ignore stale wakes.
 		}
 
@@ -204,7 +204,7 @@ func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 }
 
 func (el *eventloop) loopWake(c *stdConn) error {
-	if co, ok := el.connections[c]; !ok || co != c {
+	if _, ok := el.connections[c]; !ok {
 		return nil // ignore stale wakes.
 	}
 

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -237,10 +237,6 @@ func (el *eventloop) handleAction(c *stdConn, action Action) error {
 }
 
 func (el *eventloop) loopReadUDP(c *stdConn) error {
-	if c.conn == nil {
-		return nil
-	}
-
 	out, action := el.eventHandler.React(c.buffer.Bytes(), c)
 	if out != nil {
 		el.eventHandler.PreWrite()

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -104,6 +104,10 @@ func (el *eventloop) loopAccept(c *stdConn) error {
 }
 
 func (el *eventloop) loopRead(c *stdConn) error {
+	if c.conn == nil {
+		return nil
+	}
+
 	for inFrame, _ := c.read(); inFrame != nil; inFrame, _ = c.read() {
 		out, action := el.eventHandler.React(inFrame, c)
 		if out != nil {
@@ -203,6 +207,10 @@ func (el *eventloop) loopWake(c *stdConn) error {
 	//if co, ok := el.connections[c]; !ok || co != c {
 	//	return nil // ignore stale wakes.
 	//}
+	if c.conn == nil {
+		return nil
+	}
+
 	out, action := el.eventHandler.React(nil, c)
 	if out != nil {
 		if frame, err := c.codec.Encode(c, out); err != nil {
@@ -229,6 +237,10 @@ func (el *eventloop) handleAction(c *stdConn, action Action) error {
 }
 
 func (el *eventloop) loopReadUDP(c *stdConn) error {
+	if c.conn == nil {
+		return nil
+	}
+
 	out, action := el.eventHandler.React(c.buffer.Bytes(), c)
 	if out != nil {
 		el.eventHandler.PreWrite()

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -180,8 +180,8 @@ func (el *eventloop) loopTicker() {
 
 func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 	defer func() {
-		if c.conn == nil {
-			return
+		if co, ok := el.connections[c]; !ok || co != c {
+			return nil // ignore stale wakes.
 		}
 
 		if err = c.conn.Close(); err != nil {
@@ -204,11 +204,8 @@ func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 }
 
 func (el *eventloop) loopWake(c *stdConn) error {
-	//if co, ok := el.connections[c]; !ok || co != c {
-	//	return nil // ignore stale wakes.
-	//}
-	if c.conn == nil {
-		return nil
+	if co, ok := el.connections[c]; !ok || co != c {
+		return nil // ignore stale wakes.
 	}
 
 	out, action := el.eventHandler.React(nil, c)

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -180,6 +180,10 @@ func (el *eventloop) loopTicker() {
 
 func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 	defer func() {
+		if c.conn == nil {
+			return
+		}
+
 		if err = c.conn.Close(); err != nil {
 			el.svr.logger.Warnf("Failed to close connection(%s), error: %v", c.remoteAddr.String(), err)
 			if e == nil {
@@ -203,6 +207,10 @@ func (el *eventloop) loopWake(c *stdConn) error {
 	//if co, ok := el.connections[c]; !ok || co != c {
 	//	return nil // ignore stale wakes.
 	//}
+	if c.conn == nil {
+		return nil
+	}
+
 	out, action := el.eventHandler.React(nil, c)
 	if out != nil {
 		if frame, err := c.codec.Encode(c, out); err != nil {

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -181,7 +181,7 @@ func (el *eventloop) loopTicker() {
 func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 	defer func() {
 		if _, ok := el.connections[c]; !ok {
-			return nil // ignore stale wakes.
+			return // ignore stale wakes.
 		}
 
 		if err = c.conn.Close(); err != nil {

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -184,6 +184,10 @@ func (el *eventloop) loopTicker() {
 
 func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 	defer func() {
+		if c.conn == nil {
+			return
+		}
+
 		if err = c.conn.Close(); err != nil {
 			el.svr.logger.Warnf("Failed to close connection(%s), error: %v", c.remoteAddr.String(), err)
 			if e == nil {

--- a/eventloop_windows.go
+++ b/eventloop_windows.go
@@ -104,10 +104,6 @@ func (el *eventloop) loopAccept(c *stdConn) error {
 }
 
 func (el *eventloop) loopRead(c *stdConn) error {
-	if c.conn == nil {
-		return nil
-	}
-
 	for inFrame, _ := c.read(); inFrame != nil; inFrame, _ = c.read() {
 		out, action := el.eventHandler.React(inFrame, c)
 		if out != nil {
@@ -184,10 +180,6 @@ func (el *eventloop) loopTicker() {
 
 func (el *eventloop) loopError(c *stdConn, err error) (e error) {
 	defer func() {
-		if c.conn == nil {
-			return
-		}
-
 		if err = c.conn.Close(); err != nil {
 			el.svr.logger.Warnf("Failed to close connection(%s), error: %v", c.remoteAddr.String(), err)
 			if e == nil {
@@ -211,10 +203,6 @@ func (el *eventloop) loopWake(c *stdConn) error {
 	//if co, ok := el.connections[c]; !ok || co != c {
 	//	return nil // ignore stale wakes.
 	//}
-	if c.conn == nil {
-		return nil
-	}
-
 	out, action := el.eventHandler.React(nil, c)
 	if out != nil {
 		if frame, err := c.codec.Encode(c, out); err != nil {

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1137,8 +1137,8 @@ func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
 	// actually goroutines here needed only on windows since its async actions
 	// rely on an unbuffered channel and since we already into it - this will
 	// block forever.
-	go must(conn.Wake())
-	go must(conn.Close())
+	go func() { must(conn.Wake()) }()
+	go func() { must(conn.Close()) }()
 
 	<-tes.clientClosed
 

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1134,8 +1134,11 @@ func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
 		close(tes.readen)
 	}
 
-	must(conn.Wake())
-	must(conn.Close())
+	// actually goroutines here needed only on windows since its async actions
+	// rely on an unbuffered channel and since we already into it - this will
+	// block forever.
+	go must(conn.Wake())
+	go must(conn.Close())
 
 	<-tes.clientClosed
 

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1089,8 +1089,6 @@ func testStop(network, addr string) {
 type testClosedWakeUpServer struct {
 	*EventServer
 	network, addr, protoAddr string
-
-	stopped chan struct{}
 }
 
 func (tes *testClosedWakeUpServer) OnInitComplete(_ Server) (action Action) {
@@ -1118,6 +1116,7 @@ func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
 	conn.ResetBuffer()
 
 	must(conn.Wake())
+	must(conn.AsyncWrite([]byte("hi")))
 
 	return nil, Close
 }
@@ -1125,7 +1124,6 @@ func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
 func TestClosedWakeUp(t *testing.T) {
 	events := &testClosedWakeUpServer{
 		EventServer: &EventServer{}, network: "tcp", addr: ":8888", protoAddr: "tcp://:8888",
-		stopped: make(chan struct{}),
 	}
 
 	must(Serve(events, events.protoAddr))

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1106,11 +1106,7 @@ func (tes *testClosedWakeUpServer) OnInitComplete(_ Server) (action Action) {
 			panic(err)
 		}
 
-		select {
-		case <-time.After(time.Second):
-			// panic("task is not executed in time")
-		// case <-tes.stopped:
-		}
+		<-time.After(time.Second)
 
 		fmt.Println("stop server...", Stop(context.TODO(), tes.protoAddr))
 	}()

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1146,7 +1146,11 @@ func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
 }
 
 func (tes *testClosedWakeUpServer) OnClosed(c Conn, err error) (action Action) {
-	close(tes.serverClosed)
+	select {
+	case <-tes.serverClosed:
+	default:
+		close(tes.serverClosed)
+	}
 	return
 }
 

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1096,12 +1096,12 @@ type testClosedWakeUpServer struct {
 }
 
 func (tes *testClosedWakeUpServer) OnInitComplete(_ Server) (action Action) {
-	c, err := net.Dial(tes.network, tes.addr)
-	if err != nil {
-		panic(err)
-	}
-
 	go func() {
+		c, err := net.Dial(tes.network, tes.addr)
+		if err != nil {
+			panic(err)
+		}
+
 		_, err = c.Write([]byte("hello"))
 		if err != nil {
 			panic(err)
@@ -1123,7 +1123,7 @@ func (tes *testClosedWakeUpServer) OnInitComplete(_ Server) (action Action) {
 	return None
 }
 
-func (tes *testClosedWakeUpServer) React(bts []byte, conn Conn) ([]byte, Action) {
+func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
 	if conn.RemoteAddr() == nil {
 		panic("react on closed conn")
 	}

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1124,7 +1124,9 @@ func (tes *testClosedWakeUpServer) OnInitComplete(_ Server) (action Action) {
 }
 
 func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
-	conn.ResetBuffer()
+	if conn.RemoteAddr() == nil {
+		panic("react on closed conn")
+	}
 
 	close(tes.readen)
 

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1150,5 +1150,5 @@ func TestClosedWakeUp(t *testing.T) {
 		readen:       make(chan struct{}),
 	}
 
-	must(Serve(events, events.protoAddr, WithReusePort(true)))
+	must(Serve(events, events.protoAddr))
 }

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1104,7 +1104,7 @@ func (tes *testClosedWakeUpServer) OnInitComplete(_ Server) (action Action) {
 			panic(err)
 		}
 
-		<-time.After(time.Second)
+		<-time.After(time.Millisecond*300)
 
 		fmt.Println("stop server...", Stop(context.TODO(), tes.protoAddr))
 	}()
@@ -1116,11 +1116,11 @@ func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
 	conn.ResetBuffer()
 
 	must(conn.Wake())
-	must(conn.AsyncWrite([]byte("hi")))
 
 	return nil, Close
 }
 
+// Test should not panic when we wake-up closed conn.
 func TestClosedWakeUp(t *testing.T) {
 	events := &testClosedWakeUpServer{
 		EventServer: &EventServer{}, network: "tcp", addr: ":8888", protoAddr: "tcp://:8888",

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1128,7 +1128,9 @@ func (tes *testClosedWakeUpServer) React(bts []byte, conn Conn) ([]byte, Action)
 		panic("react on closed conn")
 	}
 
-	if string(bts) == "hello" {
+	select {
+	case <-tes.readen:
+	default:
 		close(tes.readen)
 	}
 

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1123,12 +1123,14 @@ func (tes *testClosedWakeUpServer) OnInitComplete(_ Server) (action Action) {
 	return None
 }
 
-func (tes *testClosedWakeUpServer) React(_ []byte, conn Conn) ([]byte, Action) {
+func (tes *testClosedWakeUpServer) React(bts []byte, conn Conn) ([]byte, Action) {
 	if conn.RemoteAddr() == nil {
 		panic("react on closed conn")
 	}
 
-	close(tes.readen)
+	if string(bts) == "hello" {
+		close(tes.readen)
+	}
 
 	must(conn.Wake())
 	must(conn.Close())


### PR DESCRIPTION
## 1. Are you opening this pull request for bug-fixs, optimizations or new feature?
Bug fix


## 2. Please describe how these code changes achieve your intention.
Prevent closed conns from execute loops.



## 3. Please link to the relevant issues (if any).
#194 



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
Maybe async funcs on `Conn` interface should declare that they will not be executed if conn is closed.

