### PR TITLE
ENH: Expose unix file descriptor to gnet.Conn

### DIFF
--- a/connection_unix.go
+++ b/connection_unix.go
@@ -251,3 +251,4 @@ func (c *conn) Context() interface{}       { return c.ctx }
 func (c *conn) SetContext(ctx interface{}) { c.ctx = ctx }
 func (c *conn) LocalAddr() net.Addr        { return c.localAddr }
 func (c *conn) RemoteAddr() net.Addr       { return c.remoteAddr }
+func (c *conn) GetFD() int                 { return c.fd }

--- a/connection_windows.go
+++ b/connection_windows.go
@@ -264,3 +264,4 @@ func (c *stdConn) Context() interface{}       { return c.ctx }
 func (c *stdConn) SetContext(ctx interface{}) { c.ctx = ctx }
 func (c *stdConn) LocalAddr() net.Addr        { return c.localAddr }
 func (c *stdConn) RemoteAddr() net.Addr       { return c.remoteAddr }
+func (c *conn) GetFD() int                    { return 0 } // Windows is not supported

--- a/gnet.go
+++ b/gnet.go
@@ -106,6 +106,9 @@ type Conn interface {
 	// RemoteAddr is the connection's remote peer address.
 	RemoteAddr() (addr net.Addr)
 
+	// GetFD returns the connection's file descriptor.
+	GetFD() int
+
 	// Read reads all data from inbound ring-buffer and event-loop-buffer without moving "read" pointer, which means
 	// it does not evict the data from buffers actually and those data will present in buffers until the
 	// ResetBuffer method is called.


### PR DESCRIPTION
Exposing the file descriptor to gnet.Conn allows a developer more control over a socket, i.e. getting data from a unix domain socket. Its important to apply custom socket options for example the SO_PEERCRED.

Using custom socket options are sometimes useful for different types of networks. If everything runs on the same machine, its better to use unix domain sockets instead of tcp sockets, because you can avoid unnecessary network overlay and work directly with the unix file system, but there are some bottlenecks. Even if we set permissions for a specific unix domain socket file, we cant stop the SuperUser from accessing it. Thats why SO_PEERCRED might be useful for some implementations. But in this case we do need an File Descriptor (FD), to access the low level socket.

Example usage:
```
var cred *unix.Ucred
cred, err := unix.GetsockoptUcred(c.GetFD(), unix.SOL_SOCKET, unix.SO_PEERCRED)
if err != nil {
	return
}
fmt.Println(cred.Pid)
```

I came across this [blogpost ](https://blog.jbowen.dev/2019/09/using-so_peercred-in-go/)and thought about using SO_PEERCRED in our internal programs.

## 4. Checklist

- [ ] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
