### PR TITLE
feat: support so_reuseaddr

### DIFF
--- a/internal/socket/sockopts_posix.go
+++ b/internal/socket/sockopts_posix.go
@@ -52,6 +52,11 @@ func SetReuseport(fd, reusePort int) error {
 	return os.NewSyscallError("setsockopt", unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEPORT, reusePort))
 }
 
+// SetReuseAddr enables SO_REUSEADDR option on socket.
+func SetReuseAddr(fd, reuseAddr int) error {
+	return os.NewSyscallError("setsockopt", unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, reuseAddr))
+}
+
 // SetIPv6Only restricts a IPv6 socket to only process IPv6 requests or both IPv4 and IPv6 requests.
 func SetIPv6Only(fd, ipv6only int) error {
 	return unix.SetsockoptInt(fd, unix.IPPROTO_IPV6, unix.IPV6_V6ONLY, ipv6only)

--- a/listener_unix.go
+++ b/listener_unix.go
@@ -84,6 +84,10 @@ func initListener(network, addr string, options *Options) (l *listener, err erro
 		sockopt := socket.Option{SetSockopt: socket.SetReuseport, Opt: 1}
 		sockopts = append(sockopts, sockopt)
 	}
+	if options.ReuseAddr {
+		sockopt := socket.Option{SetSockopt: socket.SetReuseAddr, Opt: 1}
+		sockopts = append(sockopts, sockopt)
+	}
 	if options.TCPNoDelay == TCPNoDelay && strings.HasPrefix(network, "tcp") {
 		sockopt := socket.Option{SetSockopt: socket.SetNoDelay, Opt: 1}
 		sockopts = append(sockopts, sockopt)

--- a/options.go
+++ b/options.go
@@ -73,6 +73,9 @@ type Options struct {
 	// ReusePort indicates whether to set up the SO_REUSEPORT socket option.
 	ReusePort bool
 
+	// ReuseAddr indicates whether to set up the SO_REUSEADDR socket option.
+	ReuseAddr bool
+
 	// Ticker indicates whether the ticker has been set up.
 	Ticker bool
 
@@ -156,6 +159,13 @@ func WithNumEventLoop(numEventLoop int) Option {
 func WithReusePort(reusePort bool) Option {
 	return func(opts *Options) {
 		opts.ReusePort = reusePort
+	}
+}
+
+// WithReuseAddr sets up SO_REUSEADDR socket option.
+func WithReuseAddr(reuseAddr bool) Option {
+	return func(opts *Options) {
+		opts.ReuseAddr = reuseAddr
 	}
 }
 


### PR DESCRIPTION
## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?
new feature


## 2. Please describe how these code changes achieve your intention.
支持 so_reuseaddr 可以使得 gnet 在重启过程中，不必因为 timewait 原因而导致：bind: address already in use


## 3. Please link to the relevant issues (if any).
https://github.com/panjf2000/gnet/issues/266
https://github.com/panjf2000/gnet/issues/272


## 4. Which documentation changes (if any) need to be made/updated because of this PR?


## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
