### PR TITLE
feat: support so_reuseaddr

### DIFF
--- a/gnet_test.go
+++ b/gnet_test.go
@@ -48,128 +48,108 @@ func TestCodecServe(t *testing.T) {
 	t.Run("poll", func(t *testing.T) {
 		t.Run("tcp", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, false, 10, false, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, false, 10, false, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, false, 10, false, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, false, 10, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, false, 10, false, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, false, 10, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, false, 10, false, false, nil)
+				testCodecServe(t, "tcp", ":9994", false, false, 10, false, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, false, 10, false, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, false, 10, false, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, false, 10, false, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, false, 10, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, false, 10, false, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, false, 10, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, false, 10, false, false, nil)
+				testCodecServe(t, "tcp", ":9998", true, false, 10, false, nil)
 			})
 		})
 		t.Run("tcp-async", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, true, 10, false, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, true, 10, false, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, true, 10, false, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, true, 10, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, true, 10, false, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, true, 10, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, true, 10, false, false, nil)
+				testCodecServe(t, "tcp", ":9994", false, true, 10, false, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, true, 10, false, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, true, 10, false, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, true, 10, false, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, true, 10, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, true, 10, false, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, true, 10, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, true, 10, false, false, nil)
+				testCodecServe(t, "tcp", ":9998", true, true, 10, false, nil)
 			})
 		})
 	})
-
 	t.Run("poll-reuseport", func(t *testing.T) {
 		t.Run("tcp", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, false, 10, true, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, false, 10, true, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, false, 10, true, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, false, 10, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, false, 10, true, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, false, 10, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, false, 10, true, true, nil)
+				testCodecServe(t, "tcp", ":9994", false, false, 10, true, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, false, 10, true, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, false, 10, true, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, false, 10, true, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, false, 10, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, false, 10, true, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, false, 10, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, false, 10, true, true, nil)
+				testCodecServe(t, "tcp", ":9998", true, false, 10, true, nil)
 			})
 		})
 		t.Run("tcp-async", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, true, 10, true, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, true, 10, true, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, true, 10, true, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, true, 10, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, true, 10, true, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, true, 10, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, true, 10, true, true, nil)
+				testCodecServe(t, "tcp", ":9994", false, true, 10, true, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, true, 10, true, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, true, 10, true, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, true, 10, true, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, true, 10, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, true, 10, true, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, true, 10, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, true, 10, true, true, nil)
-			})
-		})
-	})
-
-	t.Run("poll-reuseaddr", func(t *testing.T) {
-		t.Run("tcp", func(t *testing.T) {
-			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, false, 10, false, true, new(LineBasedFrameCodec))
-			})
-			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", true, false, 10, false, true, new(LineBasedFrameCodec))
-			})
-		})
-		t.Run("tcp-async", func(t *testing.T) {
-			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, true, 10, false, true, new(LineBasedFrameCodec))
-			})
-			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", true, true, 10, false, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9998", true, true, 10, true, nil)
 			})
 		})
 	})
@@ -246,7 +226,6 @@ func testCodecServe(
 	multicore, async bool,
 	nclients int,
 	reuseport bool,
-	reuseaddr bool,
 	codec ICodec,
 ) {
 	var err error
@@ -288,7 +267,6 @@ func testCodecServe(
 		WithSocketSendBuffer(8*1024),
 		WithCodec(codec),
 		WithReusePort(reuseport),
-		WithReuseAddr(reuseaddr),
 	)
 	assert.NoError(t, err)
 }

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -48,108 +48,128 @@ func TestCodecServe(t *testing.T) {
 	t.Run("poll", func(t *testing.T) {
 		t.Run("tcp", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, false, 10, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, false, 10, false, false, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, false, 10, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, false, 10, false, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, false, 10, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, false, 10, false, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, false, 10, false, nil)
+				testCodecServe(t, "tcp", ":9994", false, false, 10, false, false, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, false, 10, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, false, 10, false, false, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, false, 10, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, false, 10, false, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, false, 10, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, false, 10, false, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, false, 10, false, nil)
+				testCodecServe(t, "tcp", ":9998", true, false, 10, false, false, nil)
 			})
 		})
 		t.Run("tcp-async", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, true, 10, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, true, 10, false, false, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, true, 10, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, true, 10, false, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, true, 10, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, true, 10, false, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, true, 10, false, nil)
+				testCodecServe(t, "tcp", ":9994", false, true, 10, false, false, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, true, 10, false, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, true, 10, false, false, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, true, 10, false, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, true, 10, false, false, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, true, 10, false, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, true, 10, false, false, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, true, 10, false, nil)
+				testCodecServe(t, "tcp", ":9998", true, true, 10, false, false, nil)
 			})
 		})
 	})
+
 	t.Run("poll-reuseport", func(t *testing.T) {
 		t.Run("tcp", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, false, 10, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, false, 10, true, true, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, false, 10, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, false, 10, true, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, false, 10, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, false, 10, true, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, false, 10, true, nil)
+				testCodecServe(t, "tcp", ":9994", false, false, 10, true, true, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, false, 10, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, false, 10, true, true, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, false, 10, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, false, 10, true, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, false, 10, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, false, 10, true, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, false, 10, true, nil)
+				testCodecServe(t, "tcp", ":9998", true, false, 10, true, true, nil)
 			})
 		})
 		t.Run("tcp-async", func(t *testing.T) {
 			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9991", false, true, 10, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9991", false, true, 10, true, true, new(LineBasedFrameCodec))
 			})
 			t.Run("1-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9992", false, true, 10, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9992", false, true, 10, true, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("1-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9993", false, true, 10, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9993", false, true, 10, true, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("1-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9994", false, true, 10, true, nil)
+				testCodecServe(t, "tcp", ":9994", false, true, 10, true, true, nil)
 			})
 			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9995", true, true, 10, true, new(LineBasedFrameCodec))
+				testCodecServe(t, "tcp", ":9995", true, true, 10, true, true, new(LineBasedFrameCodec))
 			})
 			t.Run("N-loop-DelimiterBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9996", true, true, 10, true, NewDelimiterBasedFrameCodec('|'))
+				testCodecServe(t, "tcp", ":9996", true, true, 10, true, true, NewDelimiterBasedFrameCodec('|'))
 			})
 			t.Run("N-loop-FixedLengthFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9997", true, true, 10, true, NewFixedLengthFrameCodec(64))
+				testCodecServe(t, "tcp", ":9997", true, true, 10, true, true, NewFixedLengthFrameCodec(64))
 			})
 			t.Run("N-loop-LengthFieldBasedFrameCodec", func(t *testing.T) {
-				testCodecServe(t, "tcp", ":9998", true, true, 10, true, nil)
+				testCodecServe(t, "tcp", ":9998", true, true, 10, true, true, nil)
+			})
+		})
+	})
+
+	t.Run("poll-reuseaddr", func(t *testing.T) {
+		t.Run("tcp", func(t *testing.T) {
+			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
+				testCodecServe(t, "tcp", ":9991", false, false, 10, false, true, new(LineBasedFrameCodec))
+			})
+			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
+				testCodecServe(t, "tcp", ":9992", true, false, 10, false, true, new(LineBasedFrameCodec))
+			})
+		})
+		t.Run("tcp-async", func(t *testing.T) {
+			t.Run("1-loop-LineBasedFrameCodec", func(t *testing.T) {
+				testCodecServe(t, "tcp", ":9991", false, true, 10, false, true, new(LineBasedFrameCodec))
+			})
+			t.Run("N-loop-LineBasedFrameCodec", func(t *testing.T) {
+				testCodecServe(t, "tcp", ":9992", true, true, 10, false, true, new(LineBasedFrameCodec))
 			})
 		})
 	})
@@ -226,6 +246,7 @@ func testCodecServe(
 	multicore, async bool,
 	nclients int,
 	reuseport bool,
+	reuseaddr bool,
 	codec ICodec,
 ) {
 	var err error
@@ -267,6 +288,7 @@ func testCodecServe(
 		WithSocketSendBuffer(8*1024),
 		WithCodec(codec),
 		WithReusePort(reuseport),
+		WithReuseAddr(reuseaddr),
 	)
 	assert.NoError(t, err)
 }
@@ -318,50 +340,50 @@ func TestServe(t *testing.T) {
 	t.Run("poll", func(t *testing.T) {
 		t.Run("tcp", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9991", false, false, false, 10, RoundRobin)
+				testServe(t, "tcp", ":9991", false, false, false, false, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9992", false, true, false, 10, LeastConnections)
+				testServe(t, "tcp", ":9992", false, false, true, false, 10, LeastConnections)
 			})
 		})
 		t.Run("tcp-async", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9991", false, false, true, 10, RoundRobin)
+				testServe(t, "tcp", ":9991", false, false, false, true, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9992", false, true, true, 10, LeastConnections)
+				testServe(t, "tcp", ":9992", false, false, true, true, 10, LeastConnections)
 			})
 		})
 		t.Run("udp", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9991", false, false, false, 10, RoundRobin)
+				testServe(t, "udp", ":9991", false, false, false, false, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9992", false, true, false, 10, LeastConnections)
+				testServe(t, "udp", ":9992", false, false, true, false, 10, LeastConnections)
 			})
 		})
 		t.Run("udp-async", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9991", false, false, true, 10, RoundRobin)
+				testServe(t, "udp", ":9991", false, false, false, true, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9992", false, true, true, 10, LeastConnections)
+				testServe(t, "udp", ":9992", false, false, true, true, 10, LeastConnections)
 			})
 		})
 		t.Run("unix", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet1.sock", false, false, false, 10, RoundRobin)
+				testServe(t, "unix", "gnet1.sock", false, false, false, false, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet2.sock", false, true, false, 10, SourceAddrHash)
+				testServe(t, "unix", "gnet2.sock", false, false, true, false, 10, SourceAddrHash)
 			})
 		})
 		t.Run("unix-async", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet1.sock", false, false, true, 10, RoundRobin)
+				testServe(t, "unix", "gnet1.sock", false, false, false, true, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet2.sock", false, true, true, 10, SourceAddrHash)
+				testServe(t, "unix", "gnet2.sock", false, false, true, true, 10, SourceAddrHash)
 			})
 		})
 	})
@@ -369,50 +391,101 @@ func TestServe(t *testing.T) {
 	t.Run("poll-reuseport", func(t *testing.T) {
 		t.Run("tcp", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9991", true, false, false, 10, RoundRobin)
+				testServe(t, "tcp", ":9991", true, true, false, false, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9992", true, true, false, 10, LeastConnections)
+				testServe(t, "tcp", ":9992", true, true, true, false, 10, LeastConnections)
 			})
 		})
 		t.Run("tcp-async", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9991", true, false, true, 10, RoundRobin)
+				testServe(t, "tcp", ":9991", true, true, false, true, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "tcp", ":9992", true, true, false, 10, LeastConnections)
+				testServe(t, "tcp", ":9992", true, true, true, false, 10, LeastConnections)
 			})
 		})
 		t.Run("udp", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9991", true, false, false, 10, RoundRobin)
+				testServe(t, "udp", ":9991", true, true, false, false, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9992", true, true, false, 10, LeastConnections)
+				testServe(t, "udp", ":9992", true, true, true, false, 10, LeastConnections)
 			})
 		})
 		t.Run("udp-async", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9991", true, false, false, 10, RoundRobin)
+				testServe(t, "udp", ":9991", true, true, false, false, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "udp", ":9992", true, true, true, 10, LeastConnections)
+				testServe(t, "udp", ":9992", true, true, true, true, 10, LeastConnections)
 			})
 		})
 		t.Run("unix", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet1.sock", true, false, false, 10, RoundRobin)
+				testServe(t, "unix", "gnet1.sock", true, true, false, false, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet2.sock", true, true, false, 10, LeastConnections)
+				testServe(t, "unix", "gnet2.sock", true, true, true, false, 10, LeastConnections)
 			})
 		})
 		t.Run("unix-async", func(t *testing.T) {
 			t.Run("1-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet1.sock", true, false, true, 10, RoundRobin)
+				testServe(t, "unix", "gnet1.sock", true, true, false, true, 10, RoundRobin)
 			})
 			t.Run("N-loop", func(t *testing.T) {
-				testServe(t, "unix", "gnet2.sock", true, true, true, 10, LeastConnections)
+				testServe(t, "unix", "gnet2.sock", true, true, true, true, 10, LeastConnections)
+			})
+		})
+	})
+
+	t.Run("poll-reuseaddr", func(t *testing.T) {
+		t.Run("tcp", func(t *testing.T) {
+			t.Run("1-loop", func(t *testing.T) {
+				testServe(t, "tcp", ":9991", false, true, false, false, 10, RoundRobin)
+			})
+			t.Run("N-loop", func(t *testing.T) {
+				testServe(t, "tcp", ":9992", false, true, true, false, 10, LeastConnections)
+			})
+		})
+		t.Run("tcp-async", func(t *testing.T) {
+			t.Run("1-loop", func(t *testing.T) {
+				testServe(t, "tcp", ":9991", false, true, false, true, 10, RoundRobin)
+			})
+			t.Run("N-loop", func(t *testing.T) {
+				testServe(t, "tcp", ":9992", false, true, true, false, 10, LeastConnections)
+			})
+		})
+		t.Run("udp", func(t *testing.T) {
+			t.Run("1-loop", func(t *testing.T) {
+				testServe(t, "udp", ":9991", false, true, false, false, 10, RoundRobin)
+			})
+			t.Run("N-loop", func(t *testing.T) {
+				testServe(t, "udp", ":9992", false, true, true, false, 10, LeastConnections)
+			})
+		})
+		t.Run("udp-async", func(t *testing.T) {
+			t.Run("1-loop", func(t *testing.T) {
+				testServe(t, "udp", ":9991", false, true, false, false, 10, RoundRobin)
+			})
+			t.Run("N-loop", func(t *testing.T) {
+				testServe(t, "udp", ":9992", false, true, true, true, 10, LeastConnections)
+			})
+		})
+		t.Run("unix", func(t *testing.T) {
+			t.Run("1-loop", func(t *testing.T) {
+				testServe(t, "unix", "gnet1.sock", false, true, false, false, 10, RoundRobin)
+			})
+			t.Run("N-loop", func(t *testing.T) {
+				testServe(t, "unix", "gnet2.sock", false, true, true, false, 10, LeastConnections)
+			})
+		})
+		t.Run("unix-async", func(t *testing.T) {
+			t.Run("1-loop", func(t *testing.T) {
+				testServe(t, "unix", "gnet1.sock", false, true, false, true, 10, RoundRobin)
+			})
+			t.Run("N-loop", func(t *testing.T) {
+				testServe(t, "unix", "gnet2.sock", false, true, true, true, 10, LeastConnections)
 			})
 		})
 	})
@@ -510,7 +583,7 @@ func (s *testServer) Tick() (delay time.Duration, action Action) {
 	return
 }
 
-func testServe(t *testing.T, network, addr string, reuseport, multicore, async bool, nclients int, lb LoadBalancing) {
+func testServe(t *testing.T, network, addr string, reuseport, reuseaddr, multicore, async bool, nclients int, lb LoadBalancing) {
 	ts := &testServer{
 		tester:     t,
 		network:    network,
@@ -525,6 +598,7 @@ func testServe(t *testing.T, network, addr string, reuseport, multicore, async b
 		WithLockOSThread(async),
 		WithMulticore(multicore),
 		WithReusePort(reuseport),
+		WithReuseAddr(reuseaddr),
 		WithTicker(true),
 		WithTCPKeepAlive(time.Minute*1),
 		WithTCPNoDelay(TCPDelay),

--- a/internal/socket/sockopts_posix.go
+++ b/internal/socket/sockopts_posix.go
@@ -46,10 +46,12 @@ func SetSendBuffer(fd, size int) error {
 
 // SetReuseport enables SO_REUSEPORT option on socket.
 func SetReuseport(fd, reusePort int) error {
-	if err := os.NewSyscallError("setsockopt", unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, reusePort)); err != nil {
-		return err
-	}
 	return os.NewSyscallError("setsockopt", unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEPORT, reusePort))
+}
+
+// SetReuseAddr enables SO_REUSEADDR option on socket.
+func SetReuseAddr(fd, reuseAddr int) error {
+	return os.NewSyscallError("setsockopt", unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, reuseAddr))
 }
 
 // SetIPv6Only restricts a IPv6 socket to only process IPv6 requests or both IPv4 and IPv6 requests.

--- a/listener_unix.go
+++ b/listener_unix.go
@@ -84,6 +84,10 @@ func initListener(network, addr string, options *Options) (l *listener, err erro
 		sockopt := socket.Option{SetSockopt: socket.SetReuseport, Opt: 1}
 		sockopts = append(sockopts, sockopt)
 	}
+	if options.ReuseAddr {
+		sockopt := socket.Option{SetSockopt: socket.SetReuseAddr, Opt: 1}
+		sockopts = append(sockopts, sockopt)
+	}
 	if options.TCPNoDelay == TCPNoDelay && strings.HasPrefix(network, "tcp") {
 		sockopt := socket.Option{SetSockopt: socket.SetNoDelay, Opt: 1}
 		sockopts = append(sockopts, sockopt)

--- a/options.go
+++ b/options.go
@@ -73,6 +73,9 @@ type Options struct {
 	// ReusePort indicates whether to set up the SO_REUSEPORT socket option.
 	ReusePort bool
 
+	// ReuseAddr indicates whether to set up the SO_REUSEADDR socket option.
+	ReuseAddr bool
+
 	// Ticker indicates whether the ticker has been set up.
 	Ticker bool
 
@@ -156,6 +159,13 @@ func WithNumEventLoop(numEventLoop int) Option {
 func WithReusePort(reusePort bool) Option {
 	return func(opts *Options) {
 		opts.ReusePort = reusePort
+	}
+}
+
+// WithReuseAddr sets up SO_REUSEADDR socket option.
+func WithReuseAddr(reuseAddr bool) Option {
+	return func(opts *Options) {
+		opts.ReuseAddr = reuseAddr
 	}
 }
 


### PR DESCRIPTION
## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?
new feature


## 2. Please describe how these code changes achieve your intention.
支持 so_reuseaddr 可以使得 gnet 在重启过程中，不必因为 timewait 原因而导致：bind: address already in use


## 3. Please link to the relevant issues (if any).
ISSUES https://github.com/panjf2000/gnet/issues/266
ISSUES https://github.com/panjf2000/gnet/issues/272
PR https://github.com/panjf2000/gnet/pull/275

## 4. Which documentation changes (if any) need to be made/updated because of this PR?


## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
