### PR TITLE
opt: implement zero-allocated []byte pool for reusing bytes

### DIFF
--- a/pkg/pool/byteslice/byteslice.go
+++ b/pkg/pool/byteslice/byteslice.go
@@ -53,10 +53,10 @@ func (p *Pool) Get(size int) (buf []byte) {
 	if ptr == nil {
 		return make([]byte, 1<<idx)[:size]
 	}
-	slice := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
-	slice.Data = uintptr(ptr)
-	slice.Len = size
-	slice.Cap = 1 << idx
+	sh := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
+	sh.Data = uintptr(ptr)
+	sh.Len = size
+	sh.Cap = 1 << idx
 	runtime.KeepAlive(ptr)
 	return
 }

--- a/pkg/pool/byteslice/byteslice.go
+++ b/pkg/pool/byteslice/byteslice.go
@@ -17,7 +17,10 @@ package byteslice
 import (
 	"math"
 	"math/bits"
+	"reflect"
+	"runtime"
 	"sync"
+	"unsafe"
 )
 
 var builtinPool Pool
@@ -38,7 +41,7 @@ func Put(buf []byte) {
 }
 
 // Get retrieves a byte slice of the length requested by the caller from pool or allocates a new one.
-func (p *Pool) Get(size int) []byte {
+func (p *Pool) Get(size int) (buf []byte) {
 	if size <= 0 {
 		return nil
 	}
@@ -46,11 +49,16 @@ func (p *Pool) Get(size int) []byte {
 		return make([]byte, size)
 	}
 	idx := index(uint32(size))
-	if v := p.pools[idx].Get(); v != nil {
-		bp := v.(*[]byte)
-		return (*bp)[:size]
+	ptr, _ := p.pools[idx].Get().(unsafe.Pointer)
+	if ptr == nil {
+		return make([]byte, 1<<idx)[:size]
 	}
-	return make([]byte, 1<<idx)[:size]
+	slice := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
+	slice.Data = uintptr(ptr)
+	slice.Len = size
+	slice.Cap = 1 << idx
+	runtime.KeepAlive(ptr)
+	return
 }
 
 // Put returns the byte slice to the pool.
@@ -63,7 +71,8 @@ func (p *Pool) Put(buf []byte) {
 	if size != 1<<idx { // this byte slice is not from Pool.Get(), put it into the previous interval of idx
 		idx--
 	}
-	p.pools[idx].Put(&buf)
+	// array pointer
+	p.pools[idx].Put(unsafe.Pointer(&buf[:1][0]))
 }
 
 func index(n uint32) uint32 {

--- a/pkg/pool/byteslice/byteslice_test.go
+++ b/pkg/pool/byteslice/byteslice_test.go
@@ -1,0 +1,49 @@
+package byteslice
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestByteSlice(t *testing.T) {
+	buf := Get(8)
+	copy(buf, "ff")
+	if string(buf[:2]) != "ff" {
+		t.Fatal("expect copy result is ff, but not")
+	}
+
+	// Disable GC to test re-acquire the same data
+	gc := debug.SetGCPercent(-1)
+
+	Put(buf)
+
+	newBuf := Get(7)
+	if &newBuf[0] != &buf[0] {
+		t.Fatal("expect newBuf and buf to be the same array")
+	}
+	if string(newBuf[:2]) != "ff" {
+		t.Fatal("expect the newBuf is the buf, but not")
+	}
+
+	// Re-enable GC
+	debug.SetGCPercent(gc)
+}
+
+func BenchmarkByteSlice(b *testing.B) {
+	b.Run("Run.N", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			bs := Get(1024)
+			Put(bs)
+		}
+	})
+	b.Run("Run.Parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				bs := Get(1024)
+				Put(bs)
+			}
+		})
+	})
+}


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: 'zero-allocated []byte pool'
labels: 
assignees: 
---

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?

Optimizations

## 2. Please describe how these code changes achieve your intention.

**old**

```go
go test -bench=. -run=none -benchtime=3s -benchmem -memprofile=old.mem.pprof
goos: linux
goarch: amd64
pkg: github.com/panjf2000/gnet/pkg/pool/byteslice
cpu: Intel(R) Xeon(R) CPU E3-1230 V2 @ 3.30GHz
BenchmarkByteSlice/Run.N-8              51881646                63.92 ns/op           24 B/op          1 allocs/op
BenchmarkByteSlice/Run.Parallel-8       100000000               34.31 ns/op           24 B/op          1 allocs/op
PASS
ok      github.com/panjf2000/gnet/pkg/pool/byteslice    6.875s
```

![old](https://user-images.githubusercontent.com/4979407/145504683-7e95ce77-afa8-46a3-aa95-3d356609690a.png)

------

**new**

```go
go test -bench=. -run=none -benchtime=3s -benchmem -memprofile=new.mem.pprof
goos: linux
goarch: amd64
pkg: github.com/panjf2000/gnet/pkg/pool/byteslice
cpu: Intel(R) Xeon(R) CPU E3-1230 V2 @ 3.30GHz
BenchmarkByteSlice/Run.N-8              144629972               24.83 ns/op            0 B/op          0 allocs/op
BenchmarkByteSlice/Run.Parallel-8       577906443                5.676 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/panjf2000/gnet/pkg/pool/byteslice    10.049s
```

![new](https://user-images.githubusercontent.com/4979407/145504711-b95d48f5-fae9-4a07-8737-9734ac44d863.png)

------

[byteslice.mem.pprof.21121010.zip](https://github.com/panjf2000/gnet/files/7689590/byteslice.mem.pprof.21121010.zip)

## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
