### PR TITLE
fix bug about TCP_NODELAY

### DIFF
--- a/client.go
+++ b/client.go
@@ -152,8 +152,8 @@ func (cli *Client) Dial(network, address string) (Conn, error) {
 	}
 
 	if strings.HasPrefix(network, "tcp") {
-		if cli.opts.TCPNoDelay == TCPNoDelay {
-			if err = socket.SetNoDelay(DupFD, 1); err != nil {
+		if cli.opts.TCPNoDelay == TCPDelay {
+			if err = socket.SetNoDelay(DupFD, 0); err != nil {
 				return nil, err
 			}
 		}

--- a/connection_windows.go
+++ b/connection_windows.go
@@ -78,6 +78,13 @@ func packUDPConn(c *stdConn, buf []byte) *udpConn {
 	return packet
 }
 
+func boolint(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 func newTCPConn(conn net.Conn, el *eventloop) (c *stdConn) {
 	c = &stdConn{
 		conn:          conn,
@@ -95,13 +102,7 @@ func newTCPConn(conn net.Conn, el *eventloop) (c *stdConn) {
 	if tc, ok = conn.(*net.TCPConn); !ok {
 		return
 	}
-	var noDelay bool
-	switch el.svr.opts.TCPNoDelay {
-	case TCPNoDelay:
-		noDelay = true
-	case TCPDelay:
-	}
-	_ = tc.SetNoDelay(noDelay)
+	_ = tc.SetNoDelay(boolint(el.svr.opts.TCPNoDelay))
 	if el.svr.opts.TCPKeepAlive > 0 {
 		_ = tc.SetKeepAlive(true)
 		_ = tc.SetKeepAlivePeriod(el.svr.opts.TCPKeepAlive)

--- a/listener_unix.go
+++ b/listener_unix.go
@@ -88,8 +88,8 @@ func initListener(network, addr string, options *Options) (l *listener, err erro
 		sockOpt := socket.Option{SetSockOpt: socket.SetReuseAddr, Opt: 1}
 		sockOpts = append(sockOpts, sockOpt)
 	}
-	if options.TCPNoDelay == TCPNoDelay && strings.HasPrefix(network, "tcp") {
-		sockOpt := socket.Option{SetSockOpt: socket.SetNoDelay, Opt: 1}
+	if options.TCPNoDelay == TCPDelay && strings.HasPrefix(network, "tcp") {
+		sockOpt := socket.Option{SetSockOpt: socket.SetNoDelay, Opt: 0}
 		sockOpts = append(sockOpts, sockOpt)
 	}
 	if options.SocketRecvBuffer > 0 {

--- a/options.go
+++ b/options.go
@@ -36,8 +36,8 @@ type TCPSocketOpt int
 
 // Available TCP socket options.
 const (
-	TCPNoDelay TCPSocketOpt = iota
-	TCPDelay
+	TCPDelay TCPSocketOpt = iota
+	TCPNoDelay
 )
 
 // Options are configurations for the gnet application.


### PR DESCRIPTION
**Bug**

TCP_NODELAY is always set to true, which means we will always turn off Nagle's algorithm even if we config `TCP_NODELAY = false`.

As we know, TCP_NODELAY is set to `true` is a default to a lot framework, Netty talks about it from [Consider turning on TCP_NODELAY by default](https://github.com/netty/netty/issues/939).

Golang is also set TCP_NODELAY to `true` by default, you can provide it in this website: [Control packet flow with TCP_NODELAY in Go](https://blog.gopheracademy.com/advent-2019/control-packetflow-tcp-nodelay/).

So we can find code in https://github.com/panjf2000/gnet/blob/dev/listener_unix.go#L92 is ineffectual, and even if we set `options.TCPNoDelay == TCPDelay`, no code will set TCP_NODELAY to false. That is to say,

- if `options.TCPNoDelay == TCPNoDelay`, the default valeu of  TCP_NODELAY  is already true, we should do nothing
- if `options.TCPNoDelay == TCPDelay`, no codes will set TCP_NODELAY to false in gnet
---
**Constant naming problem**

From https://github.com/panjf2000/gnet/blob/dev/options.go#L39 we can find `TCPNoDelay=0`, `TCPDelay=1`, but we can find `TCPDelay=0`, `TCPNoDelay=1`in the official library. It may lead to semantic confusion.

This idea comes from the following website:
- https://github.com/golang/go/blob/master/src/net/sockopt_posix.go#L16
- https://github.com/golang/go/blob/master/src/net/tcpsockopt_posix.go#L15

But I must say it may cause forward compatibility problem, if some one use `0` and `1` instead of `gnet.TCPDelay` and `gnet.TCPNoDelay`.
