### PR TITLE
performance optimization

### DIFF
--- a/internal/netpoll/epoll_events.go
+++ b/internal/netpoll/epoll_events.go
@@ -59,6 +59,6 @@ func (el *eventList) expand() {
 func (el *eventList) shrink() {
 	if newSize := el.size >> 1; newSize >= MinPollEventsCap {
 		el.size = newSize
-		el.events = make([]epollevent, newSize)
+		el.events = el.events[:newSize]
 	}
 }

--- a/internal/netpoll/kqueue_events.go
+++ b/internal/netpoll/kqueue_events.go
@@ -59,6 +59,6 @@ func (el *eventList) expand() {
 func (el *eventList) shrink() {
 	if newSize := el.size >> 1; newSize >= MinPollEventsCap {
 		el.size = newSize
-		el.events = make([]unix.Kevent_t, newSize)
+		el.events = el.events[:newSize]
 	}
 }


### PR DESCRIPTION
It makes sense to reuse `[]epollevent` instead of make a new `[]epollevent` when shrink, which helps performance optimization.