### PR TITLE
fix bug:TCP_NODELAY is always true in client

### DIFF
--- a/client.go
+++ b/client.go
@@ -152,10 +152,16 @@ func (cli *Client) Dial(network, address string) (Conn, error) {
 	}
 
 	if strings.HasPrefix(network, "tcp") {
-		if cli.opts.TCPNoDelay == TCPNoDelay {
+		switch cli.opts.TCPNoDelay {
+		case TCPDelay:
+			if err = socket.SetNoDelay(DupFD, 0); err != nil {
+				return nil, err
+			}
+		case TCPNoDelay:
 			if err = socket.SetNoDelay(DupFD, 1); err != nil {
 				return nil, err
 			}
+		default:
 		}
 		if cli.opts.TCPKeepAlive > 0 {
 			if err = socket.SetKeepAlive(DupFD, int(cli.opts.TCPKeepAlive/time.Second)); err != nil {

--- a/client.go
+++ b/client.go
@@ -152,16 +152,10 @@ func (cli *Client) Dial(network, address string) (Conn, error) {
 	}
 
 	if strings.HasPrefix(network, "tcp") {
-		switch cli.opts.TCPNoDelay {
-		case TCPDelay:
+		if cli.opts.TCPNoDelay == TCPDelay {
 			if err = socket.SetNoDelay(DupFD, 0); err != nil {
 				return nil, err
 			}
-		case TCPNoDelay:
-			if err = socket.SetNoDelay(DupFD, 1); err != nil {
-				return nil, err
-			}
-		default:
 		}
 		if cli.opts.TCPKeepAlive > 0 {
 			if err = socket.SetKeepAlive(DupFD, int(cli.opts.TCPKeepAlive/time.Second)); err != nil {


### PR DESCRIPTION
The relevant closed pr: #309

The server in gnet is set `TCPNoDelay = flase` by default.

The Client in gnet use `net` package, which can be seen from https://github.com/panjf2000/gnet/blob/dev/client.go#L128

In my test, client in gnet is always set to `TCPNoDelay = true` even if you set it by `gnet.WithTCPNoDelay(gnet.TCPDelay)`, because `net` package set `TCPNoDelay = true` by default, which can be confirmed in https://github.com/golang/go/blob/master/src/net/tcpsock.go#L222


