### PR TITLE
fix the bug of the return value of conn.WriteTo

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -367,7 +367,7 @@ func (c *conn) WriteTo(w io.Writer) (n int64, err error) {
 	var m int
 	m, err = w.Write(c.buffer)
 	c.buffer = c.buffer[m:]
-	return int64(m), err
+	return n + int64(m), err
 }
 
 func (c *conn) Flush() error {


### PR DESCRIPTION
Change-Id: I04c0e0b0d4ef9502195b38a545f04c9f1bc305af

---
name: Pull request
about: Bug fix
title: 'fix the bug of the return value of conn.WriteTo'
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `gnet`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?

bug-fixs

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

conn.WriteTo should return the number of bytes actually written

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->

https://github.com/panjf2000/gnet/issues/343

## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

connection.go

## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
