### PR TITLE
Fix gnet.Conn not compatible with net.Conn on method Close

### DIFF
--- a/client.go
+++ b/client.go
@@ -214,7 +214,7 @@ func (cli *Client) Dial(network, address string) (Conn, error) {
 	}
 	err = cli.el.poller.UrgentTrigger(cli.el.register, gc)
 	if err != nil {
-		gc.Close(nil)
+		gc.Close()
 		return nil, err
 	}
 	return gc, nil

--- a/client_test.go
+++ b/client_test.go
@@ -315,7 +315,7 @@ func startGnetClient(t *testing.T, cli *Client, ev *clientEvents, network, addr 
 	rand.Seed(time.Now().UnixNano())
 	c, err := cli.Dial(network, addr)
 	require.NoError(t, err)
-	defer c.Close(nil)
+	defer c.Close()
 	var rspCh chan []byte
 	if network == "udp" {
 		rspCh = make(chan []byte, 1)

--- a/connection.go
+++ b/connection.go
@@ -442,12 +442,19 @@ func (c *conn) Wake(callback AsyncCallback) error {
 	}, nil)
 }
 
-func (c *conn) Close(callback AsyncCallback) error {
+func (c *conn) CloseWithCallback(callback AsyncCallback) error {
 	return c.loop.poller.Trigger(func(_ interface{}) (err error) {
 		err = c.loop.closeConn(c, nil)
 		if callback != nil {
 			_ = callback(c)
 		}
+		return
+	}, nil)
+}
+
+func (c *conn) Close() error {
+	return c.loop.poller.Trigger(func(_ interface{}) (err error) {
+		err = c.loop.closeConn(c, nil)
 		return
 	}, nil)
 }

--- a/gnet.go
+++ b/gnet.go
@@ -227,7 +227,10 @@ type Conn interface {
 
 	// Close closes the current connection, usually you don't need to pass a non-nil callback
 	// because you should use OnClose() instead, the callback here is only for compatibility.
-	Close(callback AsyncCallback) (err error)
+	CloseWithCallback(callback AsyncCallback) (err error)
+
+	// Close closes the current connection, implements net.Conn.
+	Close() (err error)
 }
 
 type (

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -834,7 +834,7 @@ func (t *testCloseConnectionServer) OnTraffic(c Conn) (action Action) {
 	_, _ = c.Discard(-1)
 	go func() {
 		time.Sleep(time.Second)
-		_ = c.Close(nil)
+		_ = c.Close()
 	}()
 	return
 }
@@ -983,7 +983,7 @@ func (s *testClosedWakeUpServer) OnTraffic(c Conn) Action {
 	}
 
 	go func() { require.NoError(s.tester, c.Wake(nil)) }()
-	go func() { require.NoError(s.tester, c.Close(nil)) }()
+	go func() { require.NoError(s.tester, c.Close()) }()
 
 	<-s.clientClosed
 


### PR DESCRIPTION
net.Conn 的Close() method的function signature是Close() error, 而gnet.Conn的Close() method的function signature是Close(callback AsyncCallback) error
现在把老的函数重命名成CloseWithCallback(callback AsyncCallback)
---
name: Fix gnet.Conn not compatible with net.Conn on method Close
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `gnet`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?
Yes


## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->


## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [ ] I have squashed all insignificant commits.
- [ ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
