### PR TITLE
fix, unix socket bind should be only used in passive mode

### DIFF
--- a/internal/socket/tcp_socket.go
+++ b/internal/socket/tcp_socket.go
@@ -124,10 +124,10 @@ func tcpSocket(proto, addr string, passive bool, sockOpts ...Option) (fd int, ne
 	}
 	defer func() {
 		// ignore EINPROGRESS for non-blocking socket connect, should be processed by caller
-		if t, ok := err.(*os.SyscallError); ok && t.Err == unix.EINPROGRESS {
-			return
-		}
 		if err != nil {
+			if err, ok := err.(*os.SyscallError); ok && err.Err == unix.EINPROGRESS {
+				return
+			}
 			_ = unix.Close(fd)
 		}
 	}()

--- a/internal/socket/tcp_socket.go
+++ b/internal/socket/tcp_socket.go
@@ -123,6 +123,10 @@ func tcpSocket(proto, addr string, passive bool, sockOpts ...Option) (fd int, ne
 		return
 	}
 	defer func() {
+		// ignore EINPROGRESS for non-blocking socket connect, should be processed by caller
+		if t, ok := err.(*os.SyscallError); ok && t.Err == unix.EINPROGRESS {
+			return
+		}
 		if err != nil {
 			_ = unix.Close(fd)
 		}
@@ -140,11 +144,10 @@ func tcpSocket(proto, addr string, passive bool, sockOpts ...Option) (fd int, ne
 		}
 	}
 
-	if err = os.NewSyscallError("bind", unix.Bind(fd, sa)); err != nil {
-		return
-	}
-
 	if passive {
+		if err = os.NewSyscallError("bind", unix.Bind(fd, sa)); err != nil {
+			return
+		}
 		// Set backlog size to the maximum.
 		err = os.NewSyscallError("listen", unix.Listen(fd, listenerBacklogMaxSize))
 	} else {

--- a/internal/socket/udp_socket.go
+++ b/internal/socket/udp_socket.go
@@ -122,10 +122,10 @@ func udpSocket(proto, addr string, connect bool, sockOpts ...Option) (fd int, ne
 	}
 	defer func() {
 		// ignore EINPROGRESS for non-blocking socket connect, should be processed by caller
-		if t, ok := err.(*os.SyscallError); ok && t.Err == unix.EINPROGRESS {
-			return
-		}
 		if err != nil {
+			if err, ok := err.(*os.SyscallError); ok && err.Err == unix.EINPROGRESS {
+				return
+			}
 			_ = unix.Close(fd)
 		}
 	}()

--- a/internal/socket/unix_socket.go
+++ b/internal/socket/unix_socket.go
@@ -60,6 +60,11 @@ func udsSocket(proto, addr string, passive bool, sockOpts ...Option) (fd int, ne
 		return
 	}
 	defer func() {
+		// ignore EINPROGRESS for non-blocking socket connect, should be processed by caller
+		// though there is less situation for EINPROGRESS when using unix socket
+		if t, ok := err.(*os.SyscallError); ok && t.Err == unix.EINPROGRESS {
+			return
+		}
 		if err != nil {
 			_ = unix.Close(fd)
 		}

--- a/internal/socket/unix_socket.go
+++ b/internal/socket/unix_socket.go
@@ -71,11 +71,11 @@ func udsSocket(proto, addr string, passive bool, sockOpts ...Option) (fd int, ne
 		}
 	}
 
-	if err = os.NewSyscallError("bind", unix.Bind(fd, sa)); err != nil {
-		return
-	}
-
 	if passive {
+		if err = os.NewSyscallError("bind", unix.Bind(fd, sa)); err != nil {
+			return
+		}
+
 		// Set backlog size to the maximum.
 		err = os.NewSyscallError("listen", unix.Listen(fd, listenerBacklogMaxSize))
 	} else {

--- a/internal/socket/unix_socket.go
+++ b/internal/socket/unix_socket.go
@@ -62,10 +62,10 @@ func udsSocket(proto, addr string, passive bool, sockOpts ...Option) (fd int, ne
 	defer func() {
 		// ignore EINPROGRESS for non-blocking socket connect, should be processed by caller
 		// though there is less situation for EINPROGRESS when using unix socket
-		if t, ok := err.(*os.SyscallError); ok && t.Err == unix.EINPROGRESS {
-			return
-		}
 		if err != nil {
+			if err, ok := err.(*os.SyscallError); ok && err.Err == unix.EINPROGRESS {
+				return
+			}
 			_ = unix.Close(fd)
 		}
 	}()


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `gnet`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?

bug-fixes

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

unix socket bind should be only used in passive mode 
When using non-blocking socket as client, we should not close fd for EINPROGRESS error

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [ ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
