### PR TITLE
add read/write event cache and avoid extra epoll_ctl syscalls

### DIFF
--- a/internal/netpoll/epoll_default_poller.go
+++ b/internal/netpoll/epoll_default_poller.go
@@ -200,30 +200,58 @@ const (
 
 // AddReadWrite registers the given file-descriptor with readable and writable events to the poller.
 func (p *Poller) AddReadWrite(pa *PollAttachment) error {
+	if pa.Events&readWriteEvents != 0 {
+		return nil
+	}
+	pa.Events |= readWriteEvents
 	return os.NewSyscallError("epoll_ctl add",
 		unix.EpollCtl(p.fd, unix.EPOLL_CTL_ADD, pa.FD, &unix.EpollEvent{Fd: int32(pa.FD), Events: readWriteEvents}))
 }
 
 // AddRead registers the given file-descriptor with readable event to the poller.
 func (p *Poller) AddRead(pa *PollAttachment) error {
+	if pa.Events&readEvents != 0 {
+		return nil
+	}
+	pa.Events |= readEvents
+	if pa.Events != readEvents {
+		return os.NewSyscallError("epoll_ctl mod",
+			unix.EpollCtl(p.fd, unix.EPOLL_CTL_MOD, pa.FD, &unix.EpollEvent{Fd: int32(pa.FD), Events: pa.Events}))
+	}
 	return os.NewSyscallError("epoll_ctl add",
 		unix.EpollCtl(p.fd, unix.EPOLL_CTL_ADD, pa.FD, &unix.EpollEvent{Fd: int32(pa.FD), Events: readEvents}))
 }
 
 // AddWrite registers the given file-descriptor with writable event to the poller.
 func (p *Poller) AddWrite(pa *PollAttachment) error {
+	if pa.Events&writeEvents != 0 {
+		return nil
+	}
+	pa.Events |= writeEvents
+	if pa.Events != writeEvents {
+		return os.NewSyscallError("epoll_ctl mod",
+			unix.EpollCtl(p.fd, unix.EPOLL_CTL_MOD, pa.FD, &unix.EpollEvent{Fd: int32(pa.FD), Events: pa.Events}))
+	}
 	return os.NewSyscallError("epoll_ctl add",
 		unix.EpollCtl(p.fd, unix.EPOLL_CTL_ADD, pa.FD, &unix.EpollEvent{Fd: int32(pa.FD), Events: writeEvents}))
 }
 
 // ModRead renews the given file-descriptor with readable event in the poller.
 func (p *Poller) ModRead(pa *PollAttachment) error {
+	if pa.Events == readEvents {
+		return nil
+	}
+	pa.Events = readEvents
 	return os.NewSyscallError("epoll_ctl mod",
 		unix.EpollCtl(p.fd, unix.EPOLL_CTL_MOD, pa.FD, &unix.EpollEvent{Fd: int32(pa.FD), Events: readEvents}))
 }
 
 // ModReadWrite renews the given file-descriptor with readable and writable events in the poller.
 func (p *Poller) ModReadWrite(pa *PollAttachment) error {
+	if pa.Events == readWriteEvents {
+		return nil
+	}
+	pa.Events = readWriteEvents
 	return os.NewSyscallError("epoll_ctl mod",
 		unix.EpollCtl(p.fd, unix.EPOLL_CTL_MOD, pa.FD, &unix.EpollEvent{Fd: int32(pa.FD), Events: readWriteEvents}))
 }

--- a/internal/netpoll/poll_data_unix.go
+++ b/internal/netpoll/poll_data_unix.go
@@ -17,7 +17,9 @@
 
 package netpoll
 
-import "sync"
+import (
+	"sync"
+)
 
 var pollAttachmentPool = sync.Pool{New: func() interface{} { return new(PollAttachment) }}
 
@@ -31,12 +33,14 @@ func PutPollAttachment(pa *PollAttachment) {
 	if pa == nil {
 		return
 	}
-	pa.FD, pa.Callback = 0, nil
+	pa.FD, pa.Callback, pa.Events = 0, nil, 0
 	pollAttachmentPool.Put(pa)
 }
 
 // PollAttachment is the user data which is about to be stored in "void *ptr" of epoll_data or "void *udata" of kevent.
 type PollAttachment struct {
-	FD       int
+	FD int
+	// Used to cache read/write event and avoid extra epoll_ctl syscalls
+	Events   uint32
 	Callback PollEventHandler
 }


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `gnet`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?

optimizations

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

add `Events` field to the struct PollAttachment in `poll_data_unix.go`，every time we add/mod read/write poll event in `epoll_default_poller.go`, we check if the event has been added, if already exists, we return directly without any syscall 

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
