### PR TITLE
feat: add multicast UDP listener support

### DIFF
--- a/gnet_test.go
+++ b/gnet_test.go
@@ -508,6 +508,9 @@ func (s *testMcastServer) startMcastClient() {
 		require.NoError(s.t, err)
 		_, err = c.Write(reqData)
 		require.NoError(s.t, err)
+		// Workaround for MacOS "write: no buffer space available" error messages
+		// https://developer.apple.com/forums/thread/42334
+		time.Sleep(time.Millisecond)
 		select {
 		case respData := <-ch:
 			require.Equalf(s.t, reqData, respData, "response mismatch, length of bytes: %d vs %d", len(reqData), len(respData))

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"net"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -409,6 +410,101 @@ func startClient(t *testing.T, network, addr string, multicore, async bool) {
 			)
 		}
 	}
+}
+
+// NOTE: TestServeMulticast can fail with "write: no buffer space available" on wifi interface
+func TestServeMulticast(t *testing.T) {
+	// 224.0.0.169 is an unassigned address from the Local Network Control Block
+	// https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml#multicast-addresses-1
+	t.Run("udp-multicast", func(t *testing.T) {
+		testMulticast(t, "224.0.0.169:9991", false, false, 10)
+	})
+	t.Run("udp-multicast-reuseport", func(t *testing.T) {
+		testMulticast(t, "224.0.0.169:9991", true, false, 10)
+	})
+	t.Run("udp-multicast-reuseaddr", func(t *testing.T) {
+		testMulticast(t, "224.0.0.169:9991", false, true, 10)
+	})
+}
+
+func testMulticast(t *testing.T, addr string, reuseport, reuseaddr bool, nclients int) {
+	ts := &testMcastServer{
+		t:        t,
+		addr:     addr,
+		nclients: nclients,
+	}
+	err := Run(ts, "udp://"+addr,
+		WithReuseAddr(reuseaddr),
+		WithReusePort(reuseport),
+		WithSocketRecvBuffer(2*nclients*1024), // enough space to receive messages from nclients to eliminate dropped packets
+		WithTicker(true))
+	assert.NoError(t, err)
+}
+
+type testMcastServer struct {
+	*BuiltinEventEngine
+	t        *testing.T
+	mcast    sync.Map
+	addr     string
+	nclients int
+	started  int32
+	active   int32
+}
+
+func (s *testMcastServer) startMcastClient() {
+	rand.Seed(time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, err := net.Dial("udp", s.addr)
+	require.NoError(s.t, err)
+	defer c.Close()
+	ch := make(chan []byte, 10000)
+	s.mcast.Store(c.LocalAddr().String(), ch)
+	duration := time.Duration((rand.Float64()*2+1)*float64(time.Second)) / 2
+	s.t.Logf("test duration: %dms", duration/time.Millisecond)
+	start := time.Now()
+	for time.Since(start) < duration {
+		reqData := make([]byte, 1024)
+		_, err = rand.Read(reqData)
+		require.NoError(s.t, err)
+		_, err = c.Write(reqData)
+		require.NoError(s.t, err)
+		select {
+		case respData := <-ch:
+			require.Equalf(s.t, reqData, respData, "response mismatch, length of bytes: %d vs %d", len(reqData), len(respData))
+		case <-ctx.Done():
+			require.Fail(s.t, "timeout receiving message")
+			return
+		}
+	}
+}
+
+func (s *testMcastServer) OnTraffic(c Conn) (action Action) {
+	buf, _ := c.Next(-1)
+	b := make([]byte, len(buf))
+	copy(b, buf)
+	ch, ok := s.mcast.Load(c.RemoteAddr().String())
+	require.True(s.t, ok)
+	ch.(chan []byte) <- b
+	return
+}
+
+func (s *testMcastServer) OnTick() (delay time.Duration, action Action) {
+	if atomic.CompareAndSwapInt32(&s.started, 0, 1) {
+		for i := 0; i < s.nclients; i++ {
+			atomic.AddInt32(&s.active, 1)
+			go func() {
+				s.startMcastClient()
+				atomic.AddInt32(&s.active, -1)
+			}()
+		}
+	}
+	if atomic.LoadInt32(&s.active) == 0 {
+		action = Shutdown
+		return
+	}
+	delay = time.Second / 5
+	return
 }
 
 func TestDefaultGnetServer(t *testing.T) {

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -431,6 +431,9 @@ func TestServeMulticast(t *testing.T) {
 	t.Run("IPv6", func(t *testing.T) {
 		iface, err := findLoopbackInterface()
 		require.NoError(t, err)
+		if iface.Flags&net.FlagMulticast != net.FlagMulticast {
+			t.Skip("multicast is not supported on loopback interface")
+		}
 		// ff02::3 is an unassigned address from Link-Local Scope Multicast Addresses
 		// https://www.iana.org/assignments/ipv6-multicast-addresses/ipv6-multicast-addresses.xhtml#link-local
 		t.Run("udp-multicast", func(t *testing.T) {
@@ -451,11 +454,11 @@ func findLoopbackInterface() (*net.Interface, error) {
 		return nil, err
 	}
 	for _, iface := range ifaces {
-		if iface.Flags&(net.FlagLoopback|net.FlagMulticast) == net.FlagLoopback|net.FlagMulticast {
+		if iface.Flags&net.FlagLoopback == net.FlagLoopback {
 			return &iface, nil
 		}
 	}
-	return nil, errors.New("no loopback interface that supports multicast")
+	return nil, errors.New("no loopback interface")
 }
 
 func testMulticast(t *testing.T, addr string, reuseport, reuseaddr bool, index, nclients int) {

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -412,7 +412,7 @@ func startClient(t *testing.T, network, addr string, multicore, async bool) {
 	}
 }
 
-// NOTE: TestServeMulticast can fail with "write: no buffer space available" on wifi interface
+// NOTE: TestServeMulticast can fail with "write: no buffer space available" on wifi interface.
 func TestServeMulticast(t *testing.T) {
 	// 224.0.0.169 is an unassigned address from the Local Network Control Block
 	// https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml#multicast-addresses-1

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -431,7 +431,7 @@ func TestServeMulticast(t *testing.T) {
 	t.Run("IPv6", func(t *testing.T) {
 		iface, err := findLoopbackInterface()
 		require.NoError(t, err)
-		// ff02::3 is an unassigned address from Link-Local Scope Multicast Addressess
+		// ff02::3 is an unassigned address from Link-Local Scope Multicast Addresses
 		// https://www.iana.org/assignments/ipv6-multicast-addresses/ipv6-multicast-addresses.xhtml#link-local
 		t.Run("udp-multicast", func(t *testing.T) {
 			testMulticast(t, fmt.Sprintf("[ff02::3%%%s]:9991", iface.Name), false, false, iface.Index, 10)

--- a/internal/socket/sockopts_posix.go
+++ b/internal/socket/sockopts_posix.go
@@ -88,14 +88,8 @@ func SetLinger(fd, sec int) error {
 
 // SetMulticastMembership returns with a socket option function based on the IP
 // version. Returns nil when multicast membership cannot be applied.
-func SetMulticastMembership(proto, addr string) func(int, int) error {
-	var udpVersion string
-	udpAddr, err := net.ResolveUDPAddr(proto, addr)
-	if err != nil || !udpAddr.IP.IsMulticast() {
-		return nil
-	}
-
-	udpVersion, err = determineUDPProto(proto, udpAddr)
+func SetMulticastMembership(proto string, udpAddr *net.UDPAddr) func(int, int) error {
+	udpVersion, err := determineUDPProto(proto, udpAddr)
 	if err != nil {
 		return nil
 	}

--- a/listener.go
+++ b/listener.go
@@ -100,6 +100,12 @@ func initListener(network, addr string, options *Options) (l *listener, err erro
 		sockOpt := socket.Option{SetSockOpt: socket.SetSendBuffer, Opt: options.SocketSendBuffer}
 		sockOpts = append(sockOpts, sockOpt)
 	}
+	if strings.HasPrefix(network, "udp") {
+		if sockoptFn := socket.SetMulticastMembership(network, addr); sockoptFn != nil {
+			sockOpt := socket.Option{SetSockOpt: sockoptFn, Opt: options.MulticastInterfaceIndex}
+			sockOpts = append(sockOpts, sockOpt)
+		}
+	}
 	l = &listener{network: network, address: addr, sockOpts: sockOpts}
 	err = l.normalize()
 	return

--- a/listener.go
+++ b/listener.go
@@ -101,9 +101,12 @@ func initListener(network, addr string, options *Options) (l *listener, err erro
 		sockOpts = append(sockOpts, sockOpt)
 	}
 	if strings.HasPrefix(network, "udp") {
-		if sockoptFn := socket.SetMulticastMembership(network, addr); sockoptFn != nil {
-			sockOpt := socket.Option{SetSockOpt: sockoptFn, Opt: options.MulticastInterfaceIndex}
-			sockOpts = append(sockOpts, sockOpt)
+		udpAddr, err := net.ResolveUDPAddr(network, addr)
+		if err == nil && udpAddr.IP.IsMulticast() {
+			if sockoptFn := socket.SetMulticastMembership(network, udpAddr); sockoptFn != nil {
+				sockOpt := socket.Option{SetSockOpt: sockoptFn, Opt: options.MulticastInterfaceIndex}
+				sockOpts = append(sockOpts, sockOpt)
+			}
 		}
 	}
 	l = &listener{network: network, address: addr, sockOpts: sockOpts}

--- a/options.go
+++ b/options.go
@@ -63,6 +63,9 @@ type Options struct {
 	// ReusePort indicates whether to set up the SO_REUSEPORT socket option.
 	ReusePort bool
 
+	// MulticastInterfaceIndex is the index of the interface name where the multicast UDP addresses will be bound to.
+	MulticastInterfaceIndex int
+
 	// ============================= Options for both server-side and client-side =============================
 
 	// ReadBufferCap is the maximum number of bytes that can be read from the peer when the readable event comes.
@@ -237,5 +240,12 @@ func WithLogLevel(lvl logging.Level) Option {
 func WithLogger(logger logging.Logger) Option {
 	return func(opts *Options) {
 		opts.Logger = logger
+	}
+}
+
+// WithMulticastInterfaceIndex sets the interface name where UDP multicast sockets will be bound to.
+func WithMulticastInterfaceIndex(idx int) Option {
+	return func(opts *Options) {
+		opts.MulticastInterfaceIndex = idx
 	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -39,4 +39,6 @@ var (
 	ErrUnsupportedOp = errors.New("unsupported operation")
 	// ErrNegativeSize occurs when trying to pass a negative size to a buffer.
 	ErrNegativeSize = errors.New("negative size is invalid")
+	// ErrNoIPv4AddressOnInterface occurs when an IPv4 multicast address is set on an interface but IPv4 is not configured.
+	ErrNoIPv4AddressOnInterface = errors.New("no IPv4 address on interface")
 )


### PR DESCRIPTION
## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?
New feature


## 2. Please describe how these code changes achieve your intention.
This PR is intended to support UDP multicast listeners. Whenever a user wants to bind to a UDP multicast address one needs to provide additional `setsockopt` calls to make it work.



## 3. Please link to the relevant issues (if any).




## 4. Which documentation changes (if any) need to be made/updated because of this PR?
Additional configuration option: `WithMuticastInterfaceIndex`.
Examples:
```go
gnet.Run(echo, "udp://224.0.0.100:8765"))
```
or
```go
iface, _ := net.InterfaceByName("eth0")
gnet.Run(echo, "udp://224.0.0.100:8765"), gnet.WithMulticastInterfaceIndex(iface.Index))
```



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x] (optional) I am willing to help maintain this change if there are issues with it later.
