### PR TITLE
allow creation of multiple engines on the same protocol and port

### DIFF
--- a/gnet.go
+++ b/gnet.go
@@ -70,7 +70,8 @@ func (s Engine) Dup() (dupFD int, err error) {
 	return
 }
 
-// Stop this specific Engine
+// Stop gracefully shuts down this Engine without interrupting any active event-loops,
+// it waits indefinitely for connections and event-loops to be closed and then shuts down.
 func (s Engine) Stop(ctx context.Context) error {
 	if s.eng.isInShutdown() {
 		return errors.ErrEngineInShutdown
@@ -423,6 +424,7 @@ var (
 
 // Stop gracefully shuts down the engine without interrupting any active event-loops,
 // it waits indefinitely for connections and event-loops to be closed and then shuts down.
+// Deprecated: The global Stop only stops last registered Engine for the specified protocol and port combination. Use the Engine Stop function to shutdown an Engine received in the OnBoot event.
 func Stop(ctx context.Context, protoAddr string) error {
 	var eng *engine
 	if s, ok := allEngines.Load(protoAddr); ok {

--- a/gnet.go
+++ b/gnet.go
@@ -424,7 +424,7 @@ var (
 
 // Stop gracefully shuts down the engine without interrupting any active event-loops,
 // it waits indefinitely for connections and event-loops to be closed and then shuts down.
-// Deprecated: The global Stop only stops last registered Engine for the specified protocol and port combination. Use the Engine Stop function to shutdown an Engine received in the OnBoot event.
+// Deprecated: The global Stop only shuts down the last registered Engine with the same protocol and IP:Port as the previous Engine's, which can lead to leaks of Engine if you invoke gnet.Run multiple times using the same protocol and IP:Port under conditions that enable WithReuseAddr(true) and WithReusePort(true).
 func Stop(ctx context.Context, protoAddr string) error {
 	var eng *engine
 	if s, ok := allEngines.Load(protoAddr); ok {

--- a/gnet.go
+++ b/gnet.go
@@ -424,7 +424,7 @@ var (
 
 // Stop gracefully shuts down the engine without interrupting any active event-loops,
 // it waits indefinitely for connections and event-loops to be closed and then shuts down.
-// Deprecated: The global Stop only shuts down the last registered Engine with the same protocol and IP:Port as the previous Engine's, which can lead to leaks of Engine if you invoke gnet.Run multiple times using the same protocol and IP:Port under conditions that enable WithReuseAddr(true) and WithReusePort(true).
+// Deprecated: The global Stop only shuts down the last registered Engine with the same protocol and IP:Port as the previous Engine's, which can lead to leaks of Engine if you invoke gnet.Run multiple times using the same protocol and IP:Port under the condition that WithReuseAddr(true) and WithReusePort(true) are enabled. Use Engine.Stop instead.
 func Stop(ctx context.Context, protoAddr string) error {
 	var eng *engine
 	if s, ok := allEngines.Load(protoAddr); ok {

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -928,11 +928,94 @@ func testStop(t *testing.T, network, addr string) {
 	assert.NoError(t, err)
 }
 
+func TestEngineStop(t *testing.T) {
+	testEngineStop(t, "tcp", ":9998")
+}
+
+type testStopEngine struct {
+	*BuiltinEventEngine
+	tester                   *testing.T
+	network, addr, protoAddr string
+	eng                      Engine
+	stopIter                 int
+	name                     string
+	exchngCount              int
+}
+
+func (s *testStopEngine) OnBoot(eng Engine) (action Action) {
+	s.eng = eng
+	return
+}
+
+func (t *testStopEngine) OnClose(c Conn, err error) (action Action) {
+	logging.Debugf("closing connection...")
+	return
+}
+
+func (t *testStopEngine) OnTraffic(c Conn) (action Action) {
+	buf, _ := c.Peek(-1)
+	_, _ = c.Write(buf)
+	_, _ = c.Discard(-1)
+	t.exchngCount++
+	return
+}
+
+func (t *testStopEngine) OnTick() (delay time.Duration, action Action) {
+	delay = time.Millisecond * 100
+	go func() {
+		conn, err := net.Dial(t.network, t.addr)
+		require.NoError(t.tester, err)
+		defer conn.Close()
+		data := []byte("Hello World! " + t.name)
+		_, _ = conn.Write(data)
+		_, err = conn.Read(data)
+		require.NoError(t.tester, err)
+
+		if t.stopIter <= 0 {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			logging.Debugf("stop engine...", t.eng.Stop(ctx))
+			// waiting the engine shutdown.
+			_, err = conn.Read(data)
+			require.Error(t.tester, err)
+		}
+		t.stopIter--
+	}()
+	return
+}
+
+func testEngineStop(t *testing.T, network, addr string) {
+	events1 := &testStopEngine{tester: t, network: network, addr: addr, protoAddr: network + "://" + addr, name: "1", stopIter: 2}
+	events2 := &testStopEngine{tester: t, network: network, addr: addr, protoAddr: network + "://" + addr, name: "2", stopIter: 5}
+
+	result1 := make(chan error)
+	go func() {
+		err := Run(events1, events1.protoAddr, WithTicker(true), WithReuseAddr(true), WithReusePort(true))
+		result1 <- err
+	}()
+	// ensure the first handler processes before starting the next since the delay per tick is 100ms
+	time.Sleep(150 * time.Millisecond)
+	result2 := make(chan error)
+	go func() {
+		err := Run(events2, events2.protoAddr, WithTicker(true), WithReuseAddr(true), WithReusePort(true))
+		result2 <- err
+	}()
+
+	err := <-result1
+	assert.NoError(t, err)
+	err = <-result2
+	assert.NoError(t, err)
+	// make sure that each handler processed at least 1
+	require.Greater(t, events1.exchngCount, 0)
+	require.Greater(t, events2.exchngCount, 0)
+	require.Equal(t, 2+1+5+1, events1.exchngCount+events2.exchngCount)
+}
+
 // Test should not panic when we wake-up server_closed conn.
 func TestClosedWakeUp(t *testing.T) {
 	events := &testClosedWakeUpServer{
 		tester:             t,
-		BuiltinEventEngine: &BuiltinEventEngine{}, network: "tcp", addr: ":9998", protoAddr: "tcp://:9998",
+		BuiltinEventEngine: &BuiltinEventEngine{}, network: "tcp", addr: ":9999", protoAddr: "tcp://:9999",
 		clientClosed: make(chan struct{}),
 		serverClosed: make(chan struct{}),
 		wakeup:       make(chan struct{}),

--- a/gnet_test.go
+++ b/gnet_test.go
@@ -1010,6 +1010,8 @@ func testEngineStop(t *testing.T, network, addr string) {
 	require.Greater(t, events1.exchngCount, int64(0))
 	require.Greater(t, events2.exchngCount, int64(0))
 	require.Equal(t, int64(2+1+5+1), events1.exchngCount+events2.exchngCount)
+	// stop an already stopped engine
+	require.Equal(t, gerr.ErrEngineInShutdown, events1.eng.Stop(context.Background()))
 }
 
 // Test should not panic when we wake-up server_closed conn.


### PR DESCRIPTION

---
name: Pull request
about: Currently with the allEngines global map multiple engines can't be created for the same protocol and port. If they are then there is no way to Stop the first engine since any subsequent engines will overwrite the entry in the allEngines map.  Changing this map and the behavior of the gnet.Stop() is a bigger change so I merely added a Stop(..) function to the Engine so that it could Stopped and not leak.  


title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to `gnet`! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?

Yes. 

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->

Currently with the allEngines global map multiple engines can't be created for the same protocol and port. If they are then there is no way to Stop the first engine since any subsequent engines will overwrite the entry in the allEngines map.  Changing this map and the behavior of the gnet.Stop() is a bigger change so I merely added a Stop(..) function to the Engine so that it could Stopped and not leak.  

Why enable multiple engines for the same protocol & port?

When using ReuseAddr and ReusePort then it's possible to swap in a new engine to the same address & port and disable the old one without incurring a restart of the server.  This is the use case I currently have and would like to enable.  

## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->

Documentation for Engine.Stop(..) 


## 4. Checklist

- [x ] I have squashed all insignificant commits.
- [x ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [x ] I have written unit tests and verified that all tests passes (if needed).
- [? ] I have documented feature info on the README (only when this PR is adding a new feature).
- [x ] (optional) I am willing to help maintain this change if there are issues with it later.

I'm happy to add documentation to the README, just let me know if and where it makes sense?
