### PR TITLE
修复缓冲区消息多出一份的情况

### DIFF
--- a/eventloop.go
+++ b/eventloop.go
@@ -136,7 +136,7 @@ func (el *eventloop) read(c *conn) error {
 		return gerrors.ErrEngineShutdown
 	}
 	_, _ = c.inboundBuffer.Write(c.buffer)
-
+	c.buffer = c.buffer[:0]
 	return nil
 }
 


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to the code
title: '修复消息多出一份的情况'
labels: ''
assignees: ''
---

version:v2.2.5

问题场景：
1. conn首次OnTraffic响应，未消费buf数据
2. 框架会复制保存buf到inboundBuffer  `_, _ = c.inboundBuffer.Write(c.buffer) `
3. 异步协程wake唤醒conn
4. 此时conn.Peek出来的buf数据是两份  (c.inboundBuffer + c.buffer)


tcp read这里修复后已经用起来了
readUDP方法应该也需要修复测试一下


