### PR TITLE
internal/math: fix a corner case for IsPowerOfTwo

### DIFF
--- a/internal/math/math.go
+++ b/internal/math/math.go
@@ -19,9 +19,9 @@ const (
 	maxintHeadBit = 1 << (bitSize - 2)
 )
 
-// IsPowerOfTwo reports whether given integer is a power of two.
+// IsPowerOfTwo reports whether the given n is a power of two.
 func IsPowerOfTwo(n int) bool {
-	return n&(n-1) == 0
+	return n > 0 && n&(n-1) == 0
 }
 
 // CeilToPowerOfTwo returns n if it is a power-of-two, otherwise the next-highest power-of-two.


### PR DESCRIPTION
In the current implementation, if n == 0, the result is true which is incorrect.