### PR TITLE
bug: clean up the remote address regardless of c.rawConn

### DIFF
--- a/connection_windows.go
+++ b/connection_windows.go
@@ -87,9 +87,9 @@ func newTCPConn(nc net.Conn, el *eventloop) (c *conn) {
 func (c *conn) release() {
 	c.ctx = nil
 	c.localAddr = nil
+	c.remoteAddr = nil
 	if c.rawConn != nil {
 		c.rawConn = nil
-		c.remoteAddr = nil
 	}
 	c.inboundBuffer.Done()
 	bbPool.Put(c.buffer)


### PR DESCRIPTION
Fixes #544
