### PR TITLE
opt: don't disable SO_REUSEPORT on DragonFlyBSD

### DIFF
--- a/gnet.go
+++ b/gnet.go
@@ -476,8 +476,11 @@ func createListeners(addrs []string, opts ...Option) ([]*listener, *Options, err
 	//
 	// Note that FreeBSD 12 introduced a new socket option named SO_REUSEPORT_LB
 	// with the capability of load balancing, it's the equivalent of Linux's SO_REUSEPORT.
+	// Also note that DragonFlyBSD 3.6.0 extended SO_REUSEPORT to distribute workload to
+	// available sockets, which make it the same as Linux's SO_REUSEPORT.
 	goos := runtime.GOOS
-	if (options.Multicore || options.NumEventLoop > 1) && options.ReusePort && goos != "linux" && goos != "freebsd" {
+	if (options.Multicore || options.NumEventLoop > 1) && options.ReusePort &&
+		goos != "linux" && goos != "dragonfly" && goos != "freebsd" {
 		options.ReusePort = false
 	}
 

--- a/gnet.go
+++ b/gnet.go
@@ -469,9 +469,9 @@ func createListeners(addrs []string, opts ...Option) ([]*listener, *Options, err
 	// Linux implemented SO_REUSEPORT with load balancing for incoming connections
 	// while *BSD implemented it for only binding to the same address and port, which
 	// makes it pointless to enable SO_REUSEPORT on *BSD and Darwin for gnet with
-	// multiple event-loops because only the first event-loop will be constantly woken
-	// up to accept incoming connections and handle I/O events while the rest of event
-	// loops remain idle.
+	// multiple event-loops because only the first or last event-loop will be constantly
+	// woken up to accept incoming connections and handle I/O events while the rest of
+	// event-loops remain idle.
 	// Thus, we disable SO_REUSEPORT on *BSD and Darwin by default.
 	//
 	// Note that FreeBSD 12 introduced a new socket option named SO_REUSEPORT_LB


### PR DESCRIPTION
Fixes #582