### PR TITLE
opt: close file descriptor after OnClose() for UDP along with code improvement

### DIFF
--- a/client_windows.go
+++ b/client_windows.go
@@ -205,7 +205,7 @@ func (cli *Client) EnrollContext(nc net.Conn, ctx interface{}) (gc Conn, err err
 		c := newUDPConn(cli.el, nil, nc.LocalAddr(), nc.RemoteAddr())
 		c.SetContext(ctx)
 		c.rawConn = nc
-		cli.el.ch <- &openConn{c: c, isDatagram: true, cb: func() { close(connOpened) }}
+		cli.el.ch <- &openConn{c: c, cb: func() { close(connOpened) }}
 		go func(uc net.Conn, el *eventloop) {
 			var buffer [0x10000]byte
 			for {

--- a/connection_windows.go
+++ b/connection_windows.go
@@ -45,7 +45,6 @@ type udpConn struct {
 type openConn struct {
 	c          *conn
 	cb         func()
-	isDatagram bool
 }
 
 type conn struct {


### PR DESCRIPTION
Updates #621

Follows up #622

This PR also fixes the potential UDP socket leaks for Windows client.