### PR TITLE
fixed concurrent map write and read for conn matrix map

### DIFF
--- a/connection_unix.go
+++ b/connection_unix.go
@@ -52,6 +52,7 @@ type conn struct {
 	isDatagram     bool                   // UDP protocol
 	opened         bool                   // connection opened event fired
 	isEOF          bool                   // whether the connection has reached EOF
+	closeStatus    int32                  // concurrency-safe close this connection
 }
 
 func newTCPConn(fd int, el *eventloop, sa unix.Sockaddr, localAddr, remoteAddr net.Addr) (c *conn) {


### PR DESCRIPTION


## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?
bug fix


## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
There is a small chance that a connection reading data and writing data at the same time triggers el.close, resulting in concurrent read and write the connMatrix map.


## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->
fixes [#632
](https://github.com/panjf2000/gnet/issues/632)

## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [ ] I have squashed all insignificant commits.
- [ ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
