### PR TITLE
feat: support configurable I/O space to drain at a time in edge-trigg…

### DIFF
--- a/client_unix.go
+++ b/client_unix.go
@@ -106,6 +106,11 @@ func NewClient(eh EventHandler, opts ...Option) (cli *Client, err error) {
 		options.WriteBufferCap = math.CeilToPowerOfTwo(wbc)
 	}
 
+	if options.EdgeTriggeredIOSpace <= 0 {
+		options.EdgeTriggeredIOSpace = DefaultEdgeTriggeredIOSpace
+	}
+	options.EdgeTriggeredIOSpace = math.CeilToPowerOfTwo(options.EdgeTriggeredIOSpace)
+
 	el.buffer = make([]byte, options.ReadBufferCap)
 	el.connections.init()
 	el.eventHandler = eh

--- a/eventloop_unix.go
+++ b/eventloop_unix.go
@@ -125,6 +125,7 @@ func (el *eventloop) read(c *conn) error {
 
 	var recv int
 	isET := el.engine.opts.EdgeTriggeredIO
+	edgeTriggeredIOSpace := el.engine.opts.EdgeTriggeredIOSpace
 loop:
 	n, err := unix.Read(c.fd, el.buffer)
 	if err != nil || n == 0 {
@@ -150,7 +151,7 @@ loop:
 	_, _ = c.inboundBuffer.Write(c.buffer)
 	c.buffer = c.buffer[:0]
 
-	if c.isEOF || (isET && recv < el.engine.opts.EdgeTriggeredIOSpace) {
+	if c.isEOF || (isET && recv < edgeTriggeredIOSpace) {
 		goto loop
 	}
 
@@ -178,6 +179,7 @@ func (el *eventloop) write(c *conn) error {
 	}
 
 	isET := el.engine.opts.EdgeTriggeredIO
+	edgeTriggeredIOSpace := el.engine.opts.EdgeTriggeredIOSpace
 	var (
 		n    int
 		sent int
@@ -203,7 +205,7 @@ loop:
 	}
 	sent += n
 
-	if isET && !c.outboundBuffer.IsEmpty() && sent < el.engine.opts.EdgeTriggeredIOSpace {
+	if isET && !c.outboundBuffer.IsEmpty() && sent < edgeTriggeredIOSpace {
 		goto loop
 	}
 

--- a/eventloop_unix.go
+++ b/eventloop_unix.go
@@ -118,8 +118,6 @@ func (el *eventloop) read0(itf interface{}) error {
 	return el.read(itf.(*conn))
 }
 
-const maxBytesTransferET = 1 << 20
-
 func (el *eventloop) read(c *conn) error {
 	if !c.opened {
 		return nil
@@ -152,7 +150,7 @@ loop:
 	_, _ = c.inboundBuffer.Write(c.buffer)
 	c.buffer = c.buffer[:0]
 
-	if c.isEOF || (isET && recv < maxBytesTransferET) {
+	if c.isEOF || (isET && recv < el.engine.opts.EdgeTriggeredIOSpace) {
 		goto loop
 	}
 
@@ -205,7 +203,7 @@ loop:
 	}
 	sent += n
 
-	if isET && !c.outboundBuffer.IsEmpty() && sent < maxBytesTransferET {
+	if isET && !c.outboundBuffer.IsEmpty() && sent < el.engine.opts.EdgeTriggeredIOSpace {
 		goto loop
 	}
 

--- a/gnet.go
+++ b/gnet.go
@@ -418,7 +418,8 @@ func (*BuiltinEventEngine) OnTick() (delay time.Duration, action Action) {
 // MaxStreamBufferCap is the default buffer size for each stream-oriented connection(TCP/Unix).
 var MaxStreamBufferCap = 64 * 1024 // 64KB
 
-var DefaultEdgeTriggeredIOSpace = 1 << 20
+// DefaultEdgeTriggeredIOSpace is the default number of bytes that gnet can read/write up to in one event loop of ET.
+var DefaultEdgeTriggeredIOSpace = 1 << 20 // 1MB
 
 func createListeners(addrs []string, opts ...Option) ([]*listener, *Options, error) {
 	options := loadOptions(opts...)

--- a/gnet.go
+++ b/gnet.go
@@ -418,6 +418,8 @@ func (*BuiltinEventEngine) OnTick() (delay time.Duration, action Action) {
 // MaxStreamBufferCap is the default buffer size for each stream-oriented connection(TCP/Unix).
 var MaxStreamBufferCap = 64 * 1024 // 64KB
 
+var DefaultEdgeTriggeredIOSpace = 1 << 20
+
 func createListeners(addrs []string, opts ...Option) ([]*listener, *Options, error) {
 	options := loadOptions(opts...)
 
@@ -461,6 +463,11 @@ func createListeners(addrs []string, opts ...Option) ([]*listener, *Options, err
 	default:
 		options.WriteBufferCap = math.CeilToPowerOfTwo(wbc)
 	}
+
+	if options.EdgeTriggeredIOSpace <= 0 {
+		options.EdgeTriggeredIOSpace = DefaultEdgeTriggeredIOSpace
+	}
+	options.EdgeTriggeredIOSpace = math.CeilToPowerOfTwo(options.EdgeTriggeredIOSpace)
 
 	var hasUDP, hasUnix bool
 	for _, addr := range addrs {

--- a/options.go
+++ b/options.go
@@ -134,6 +134,10 @@ type Options struct {
 	// Don't enable it unless you are 100% sure what you are doing.
 	// Note that this option is only available for stream-oriented protocol.
 	EdgeTriggeredIO bool
+
+	// EdgeTriggeredIOSpace specifies the number of bytes that `gnet` can
+	// read/write up to in one event loop of ET. The default is 1MB.
+	EdgeTriggeredIOSpace int
 }
 
 // WithOptions sets up all options.
@@ -266,5 +270,12 @@ func WithMulticastInterfaceIndex(idx int) Option {
 func WithEdgeTriggeredIO(et bool) Option {
 	return func(opts *Options) {
 		opts.EdgeTriggeredIO = et
+	}
+}
+
+// WithEdgeTriggeredIOSpace set number of bytes that gnet can read/write up to in one event loop of ET.
+func WithEdgeTriggeredIOSpace(edgeTriggeredIOSpace int) Option {
+	return func(opts *Options) {
+		opts.EdgeTriggeredIOSpace = edgeTriggeredIOSpace
 	}
 }

--- a/options.go
+++ b/options.go
@@ -273,7 +273,7 @@ func WithEdgeTriggeredIO(et bool) Option {
 	}
 }
 
-// WithEdgeTriggeredIOSpace set number of bytes that gnet can read/write up to in one event loop of ET.
+// WithEdgeTriggeredIOSpace sets the number of bytes that gnet can read/write up to in one event loop of ET.
 func WithEdgeTriggeredIOSpace(edgeTriggeredIOSpace int) Option {
 	return func(opts *Options) {
 		opts.EdgeTriggeredIOSpace = edgeTriggeredIOSpace


### PR DESCRIPTION
…ered mode(#643)

<!--
Thank you for contributing to `gnet`! Please fill this out to help us review your pull request more efficiently.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fixes, optimizations or new feature?
new feature


## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
在eventloop_unix.go中将read/write函数中以前的maxBytesTransferET移除变更为了配置的值，对EdgeTriggeredIOSpace配置进行了初始化。


## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->
[#643](url)


## 4. Which documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [ ] I have squashed all insignificant commits.
- [ ] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
