### PR TITLE
test: unit tests when n > 2^32, CeilToPowerOfTwo will encounter bug

### DIFF
--- a/pkg/math/math_test.go
+++ b/pkg/math/math_test.go
@@ -1,0 +1,23 @@
+package math
+
+import "testing"
+
+func TestCeilToPowerOfTwo(t *testing.T) {
+	type args struct {
+		n int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{name: "test1", args: args{n: 1<<32 + 1}, want: 1 << 33},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CeilToPowerOfTwo(tt.args.n); got != tt.want {
+				t.Errorf("CeilToPowerOfTwo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When the parameter n is greater than 2 to the power of 32, CeilToPowerOfTwo will throw an error. Within the int64 range, the official Go code uses bits.Len64 to get the bit length, and then uses 1 << bits.Len64(uint64(n-1)) to get the result. If n is limited to the int32 range, then using bits.Len32 would be better. The benchmark results show very, very small differences, but the official code clearly executes fewer instructions when n is less than 256. Additionally, it may be more readable.