### PR TITLE
Fix: set FD_CLOEXEC flag to unix client fd

### DIFF
--- a/client_unix.go
+++ b/client_unix.go
@@ -211,6 +211,8 @@ func (cli *Client) EnrollContext(c net.Conn, ctx any) (Conn, error) {
 	var dupFD int
 	e := rc.Control(func(fd uintptr) {
 		dupFD, err = unix.Dup(int(fd))
+		// Set the socket to close-on-exec, so that the socket is closed when the process forks
+		unix.CloseOnExec(dupFD)
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you for contributing to `gnet`! Please fill this out to help us review your pull request more efficiently.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. Are you opening this pull request for bug-fix, optimization or new feature?
This PR is for bug-fix.
Currently, the Unix client fd will leak to the child process,  because we call `unix.Dup(int(fd))`--which will remove the `FD_CLOEXEC` flag--to duplicate the raw fd, and that is unsafe.

```go
	var dupFD int
	e := rc.Control(func(fd uintptr) {
		dupFD, err = unix.Dup(int(fd))	
	})
```

## 2. Please describe how these code changes achieve your intention.
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->
```go
// EnrollContext is like Enroll but also accepts an empty interface ctx that can be obtained later via Conn.Context.
func (cli *Client) EnrollContext(c net.Conn, ctx any) (Conn, error) {
	// ......
	var dupFD int
	e := rc.Control(func(fd uintptr) {
		dupFD, err = unix.Dup(int(fd))
		// Set the socket to close-on-exec, so that the socket is closed when the process forks
		unix.CloseOnExec(dupFD)
	})
	// ...... 
}
```


## 3. Please link to the relevant issues (if any).
<!-- This adds crucial context to your change. -->



## 4. What documentation changes (if any) need to be made/updated because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->



## 4. Checklist

- [x] I have squashed all insignificant commits.
- [x] I have commented my code for explaining package types, values, functions, and non-obvious lines.
- [ ] I have written unit tests and verified that all tests passes (if needed).
- [ ] I have documented feature info on the README (only when this PR is adding a new feature).
- [ ] (optional) I am willing to help maintain this change if there are issues with it later.
