### PR TITLE
ci: bump golangci-lint to v2.12.2 to fix Go 1.26 toolchain panic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup and run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.12.2
           args: -v -E gocritic -E misspell -E revive -E godot --timeout 5m
   test:
     needs: lint

--- a/.github/workflows/test_gc_opt.yml
+++ b/.github/workflows/test_gc_opt.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup and run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.12.2
           args: -v -E gocritic -E misspell -E revive -E godot --timeout 5m
   test:
     needs: lint

--- a/.github/workflows/test_poll_opt.yml
+++ b/.github/workflows/test_poll_opt.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup and run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.12.2
           args: -v -E gocritic -E misspell -E revive -E godot
   test:
     needs: lint

--- a/.github/workflows/test_poll_opt_gc_opt.yml
+++ b/.github/workflows/test_poll_opt_gc_opt.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup and run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.12.2
           args: -v -E gocritic -E misspell -E revive -E godot
   test:
     needs: lint


### PR DESCRIPTION
## Problem
CI lint jobs fail with:
```
panic: file requires newer Go version go1.26 (application built with go1.24) [recovered]
```
This happens because the pinned `golangci-lint` version (v2.1.6, built with Go 1.24) crashes when type-checking code with the Go 1.26 toolchain that `setup-go` installs (`go-version: '^1.20'` resolves to the latest 1.x, currently 1.26.4).

## Fix
Bump the pinned `golangci-lint` version from `v2.1.6` to `v2.12.2` (built with Go 1.26.2) in all 4 workflow files that run it:
- `test.yml`
- `test_gc_opt.yml`
- `test_poll_opt.yml`
- `test_poll_opt_gc_opt.yml`

## Verification
Upgraded golangci-lint locally to v2.12.2 and ran it with the exact linter flags used in CI:
```
golangci-lint run -v -E gocritic -E misspell -E revive -E godot --timeout 5m
```
Result: `0 issues`, no panic, confirming this was purely a CI tooling/version-pinning issue and not a code problem.

Reference failing run: https://github.com/panjf2000/gnet/actions/runs/28589572098/job/84769468618?pr=760